### PR TITLE
fix: Maven Central badge and scalafmt formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/galax-io/sbt-schema-registry-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/galax-io/sbt-schema-registry-plugin/actions/workflows/ci.yml)
-[![Maven Central](https://img.shields.io/maven-central/v/org.galaxio/sbt-schema-registry-plugin.svg)](https://central.sonatype.com/artifact/org.galaxio/sbt-schema-registry-plugin)
+[![Maven Central](https://img.shields.io/maven-central/v/org.galaxio/sbt-schema-registry-plugin_2.12_1.0.svg)](https://central.sonatype.com/artifact/org.galaxio/sbt-schema-registry-plugin)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 


### PR DESCRIPTION
## Summary
- Fix Maven Central version badge — was showing "not found" because it used the base artifact name instead of the cross-built SBT plugin artifact name (`sbt-schema-registry-plugin_2.12_1.0`)
- Fix scalafmt formatting in `Dependencies.scala`

## Test plan
- [ ] Verify badge renders correctly: [badge URL](https://img.shields.io/maven-central/v/org.galaxio/sbt-schema-registry-plugin_2.12_1.0.svg) should show v0.6.1
- [ ] Confirm click-through link still works on Sonatype

🤖 Generated with [Claude Code](https://claude.com/claude-code)