### PR TITLE
docs: add compatibility table, workflow integration, and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ resolvers ++= Seq(
 addSbtPlugin("org.galaxio" % "sbt-schema-registry-plugin" % "<plugin-version>")
 ```
 
+## Compatibility
+
+| sbt version | Scala version | Plugin artifact                                    |
+|-------------|---------------|----------------------------------------------------|
+| 1.x         | 2.12.x        | `sbt-schema-registry-plugin_2.12_1.0`              |
+
+The plugin is built as a standard sbt 1.x autoplugin and requires **Scala 2.12** (the Scala version used by sbt
+itself). It does **not** depend on the Scala version of your project — you can use it in a Scala 2.13 or Scala 3
+project without any changes.
+
 ## Configuration
 
 In your `build.sbt`:
@@ -30,7 +40,7 @@ import org.galaxio.avro.{RegistrySubject, SchemaRegistryAuth}
 val schemas = Seq(
   RegistrySubject("hello.world.schema", 2),      // specific version
   RegistrySubject("schema1-name", 12),            // specific version
-  RegistrySubject.latest("schema2-name"),          // latest version
+  RegistrySubject.latest("schema2-name"),          // latest version — resolved at task run time
 )
 
 lazy val root = (project in file("."))
@@ -65,8 +75,13 @@ Download all schemas listed in `schemaRegistrySubjects`:
 sbt "Compile / schemaRegistryDownload"
 ```
 
-Schema files are saved as `<subject>-<version>.avsc` in the target folder.
+Schema files are saved as `<subject>-<version>.avsc` in `schemaRegistryTargetFolder` (default: `src/main/avro`).
 The build will fail if any schema download fails.
+
+> **Output file behaviour**: every run overwrites existing `.avsc` files unconditionally. There is no
+> incremental caching — the task always fetches the schema from the registry and writes the file afresh.
+> For `RegistrySubject.latest(...)` subjects the version number is resolved at task-run time, so the
+> output filename (e.g. `my-subject-7.avsc`) may change between runs when the latest version advances.
 
 ## Settings
 
@@ -78,6 +93,129 @@ The build will fail if any schema download fails.
 | `schemaRegistryCacheSize`    | Schema registry client cache size        | `200`                  |
 | `schemaRegistryAuth`         | Authentication credentials               | `None`                 |
 | `schemaRegistryProperties`   | Additional schema registry client config | `Map.empty`            |
+
+## Workflow Integration
+
+### Run manually
+
+```bash
+sbt "Compile / schemaRegistryDownload"
+```
+
+### Hook into `compile`
+
+To ensure schemas are always downloaded before compilation, make `compile` depend on the download task:
+
+```sbt
+Compile / compile := (Compile / compile)
+  .dependsOn(Compile / schemaRegistryDownload)
+  .value
+```
+
+With this in place a plain `sbt compile` (or `sbt test`) will pull fresh schemas first.
+
+### Hook into `sourceGenerators`
+
+If you use a code-generation tool (e.g. `sbt-avro`) that reads `.avsc` files and produces Scala sources,
+register the download task as a source generator so sbt's task graph runs it before code generation:
+
+```sbt
+Compile / sourceGenerators += (Compile / schemaRegistryDownload).map(_ => Seq.empty[File])
+```
+
+This wires `schemaRegistryDownload` into the standard `sourceGenerators` chain without declaring any
+generated source files itself (the actual source generation is handled by the Avro plugin downstream).
+
+### Full example
+
+```sbt
+import org.galaxio.avro.{RegistrySubject, SchemaRegistryAuth}
+
+lazy val root = (project in file("."))
+  .settings(
+    // Schema registry connection
+    schemaRegistryUrl  := sys.env.getOrElse("SCHEMA_REGISTRY_URL", "http://localhost:8081"),
+    schemaRegistryAuth := sys.env.get("SCHEMA_REGISTRY_USER").map { user =>
+      SchemaRegistryAuth.BasicAuth(user, sys.env("SCHEMA_REGISTRY_PASSWORD"))
+    },
+
+    // Schemas to download
+    schemaRegistrySubjects ++= Seq(
+      RegistrySubject("com.example.OrderCreated", 3),
+      RegistrySubject.latest("com.example.OrderUpdated"),
+    ),
+
+    // Output directory (must match your Avro code-gen plugin's source directory)
+    schemaRegistryTargetFolder := "src/main/avro",
+
+    // Download schemas before compiling
+    Compile / compile := (Compile / compile)
+      .dependsOn(Compile / schemaRegistryDownload)
+      .value,
+  )
+```
+
+## Troubleshooting
+
+### Authentication failure (401 Unauthorized)
+
+**Symptom**: the task fails with an HTTP 401 or a message like `Unauthorized`.
+
+**Checks**:
+- Confirm the credentials are correct. Test directly:
+  ```bash
+  curl -u "$USER:$PASS" "$SCHEMA_REGISTRY_URL/subjects"
+  ```
+- Make sure `schemaRegistryAuth` is set **before** the task runs. If credentials come from environment
+  variables, verify they are exported in the shell that runs `sbt`.
+- Basic auth must be enabled on the registry side; some deployments use mTLS or token-based auth instead —
+  those require custom `schemaRegistryProperties` rather than `BasicAuth`.
+
+### SSL / TLS handshake failure
+
+**Symptom**: the task fails with `SSLHandshakeException`, `PKIX path building failed`, or similar.
+
+**Solution**: supply the truststore (and optionally keystore) via `schemaRegistryProperties`:
+
+```sbt
+schemaRegistryProperties := Map(
+  // Trust store — the CA that signed the registry's certificate
+  "schema.registry.ssl.truststore.location" -> "/etc/ssl/certs/registry-ca.jks",
+  "schema.registry.ssl.truststore.password" -> "changeit",
+
+  // Key store — only needed for mutual TLS (mTLS)
+  "schema.registry.ssl.keystore.location"   -> "/etc/ssl/certs/client.jks",
+  "schema.registry.ssl.keystore.password"   -> "changeit",
+)
+```
+
+The keys map directly to [Confluent Schema Registry client configuration properties](https://docs.confluent.io/platform/current/schema-registry/develop/api.html).
+
+If the registry certificate is signed by a well-known CA that is already in the JVM's default truststore,
+no additional configuration is required.
+
+### Subject not found (404)
+
+**Symptom**: build fails with HTTP 404 or `Subject not found`.
+
+**Checks**:
+- Verify the subject name is spelled exactly as registered (subject names are case-sensitive).
+- Confirm the requested version exists:
+  ```bash
+  curl "$SCHEMA_REGISTRY_URL/subjects/<subject-name>/versions"
+  ```
+- For `RegistrySubject.latest(...)`, ensure at least one version has been registered under that subject.
+
+### `latest` version keeps changing
+
+`RegistrySubject.latest("subject")` resolves the current latest version **at task-run time**. Each time a
+new schema version is published to the registry the downloaded file name will change (e.g. from
+`subject-4.avsc` to `subject-5.avsc`). If you need a stable, reproducible build, pin to a specific
+version number instead:
+
+```sbt
+RegistrySubject("subject", 4)   // always downloads version 4
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ lazy val root = (project in file("."))
     ),
 
     // Output directory (must match your Avro code-gen plugin's source directory)
-    schemaRegistryTargetFolder := "src/main/avro",
+    schemaRegistryTargetFolder := file("src/main/avro"),
 
     // Download schemas before compiling
     Compile / compile := (Compile / compile)


### PR DESCRIPTION
## Summary

- **Compatibility table**: explicit sbt 1.x / Scala 2.12.x matrix added after Installation, with a note clarifying the plugin works with any project Scala version.
- **Workflow Integration section**: three patterns documented — manual run, hooking into `compile` via `dependsOn`, and wiring into `sourceGenerators` for Avro code-gen pipelines. Includes a full end-to-end `build.sbt` example with env-var-based auth.
- **Output file behaviour note**: documents that files are always overwritten (no caching) and explains that `RegistrySubject.latest(...)` filenames may change between runs as new versions are published.
- **Troubleshooting section**: covers the four most common failure modes:
  - 401 Unauthorized (auth misconfiguration)
  - SSL/TLS handshake failures with truststore/keystore config examples
  - 404 Subject not found (name typos, missing versions)
  - Unstable `latest` version and how to pin to a specific version for reproducible builds

Fixes #11