### PR TITLE
chore(deps): bump all dependencies to latest compatible versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# sbt-schema-registry-plugin — Agent Guide
+
+sbt plugin for downloading Avro schemas from Confluent Schema Registry and generating sources. Published plugin — treat all public sbt keys and task behavior as compatibility-sensitive.
+
+## Role
+
+Principal Engineer in sbt plugin and Scala tooling development. Strong Scala 2.12, sbt plugin API, Confluent Schema Registry, and Avro expertise. Prefer small, clear, backward-compatible changes unless the task explicitly requires otherwise.
+
+## Stack
+
+- Scala 2.12.21, sbt 1.12.11, Java 17+
+- Confluent `kafka-schema-registry-client` 8.2.1
+- Apache Avro 1.12.1 (avro, avro-compiler)
+- ScalaTest 3.2.19 + mockito-scala-scalatest 2.0.0 (mockito-core 5.x) for unit tests
+- Testcontainers 1.21.3 (`org.testcontainers:kafka`) for integration tests (`it:test`)
+
+## Commands
+
+Format:
+```
+sbt scalafmtAll scalafmtSbt
+```
+
+Verify (default):
+```
+sbt scalafmtCheckAll scalafmtSbtCheck compile test
+```
+
+Full CI (unit tests only, no external services):
+```
+sbt compile test
+```
+
+Integration tests (requires Docker):
+```
+sbt it:test
+```
+
+Scripted (sbt plugin integration tests, if present):
+```
+sbt scripted
+```
+
+## Design Rules
+
+**KISS — one responsibility per layer:**
+`SchemaDownloaderPlugin` wires sbt tasks. `Downloader` fetches. `RegistrySubject` models subjects/versions. `SchemaRegistryAuth` handles credentials. Don't merge concerns between layers.
+
+**DRY — reuse existing abstractions:**
+`RegistrySubject` is the single model for subject + version resolution. `SchemaRegistryAuth` is the single auth abstraction. Don't invent parallel credential or subject types — extend these.
+
+**SOLID:** Each class owns one responsibility; extend via new classes/traits rather than modifying existing ones; keep sbt key interfaces narrow; inject dependencies from outside.
+
+```scala
+// ✅
+class Downloader(auth: SchemaRegistryAuth)   // inject, don't construct
+// ❌
+class Downloader { val auth = BasicAuth(...) }
+```
+
+## Boundaries
+
+✅ Always:
+- Run `sbt scalafmtAll` before committing
+- Branch from `main`; keep commits semantic and green
+- Preserve backward compatibility for published sbt keys and task behavior
+- Treat `build.sbt`, `project/Dependencies.scala`, `project/plugins.sbt` as source of truth for dependencies
+- Treat `.github/workflows/ci.yml` as source of truth for formatting, compile, tests, and release
+
+⚠️ Ask first:
+- Adding new dependencies or major-version upgrades
+- Changing public sbt key names, types, or task semantics
+- Editing another repository
+- Any change to release or publish workflow
+
+🚫 Never:
+- Force-push or commit directly to `main`
+- Add merge commits to PR branches (rebase-oriented history)
+- Commit knowingly broken code to `main`
+- Add opportunistic refactors outside task scope
+- Mock Schema Registry HTTP responses where a real integration path exists
+
+## PR Workflow
+
+1. Branch from `main`.
+2. Run verify commands before commit.
+3. Keep commits semantic and green.
+4. Prefer rebase-oriented history; avoid merge commits in PR branches.
+5. CI in `.github/workflows/ci.yml` is the source of truth for formatting, compile, tests, and release behavior.
+6. Releases are tag-driven from `main` and `v*` tags via sbt-ci-release to Sonatype; align with existing workflows rather than inventing a parallel path.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
     val avro           = "1.12.0"
     val schReqClient   = "8.0.0"
     val scalatest      = "3.2.19"
-    val mockito        = "1.17.37"
+    val mockito        = "2.0.0"
     val testcontainers = "1.19.3"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,11 +2,11 @@ import sbt.*
 
 object Dependencies {
   private object Versions {
-    val avro           = "1.12.0"
-    val schReqClient   = "8.0.0"
+    val avro           = "1.12.1"
+    val schReqClient   = "8.2.1"
     val scalatest      = "3.2.19"
     val mockito        = "2.0.0"
-    val testcontainers = "1.19.3"
+    val testcontainers = "1.21.3"
   }
 
   lazy val avroCompiler: ModuleID = "org.apache.avro" % "avro-compiler" % Versions.avro

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty"
-sbt.version=1.12.2
+sbt.version=1.12.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.5.6")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.6.1")


### PR DESCRIPTION
## Summary

- **avro**: 1.12.0 → 1.12.1 (patch)
- **kafka-schema-registry-client**: 8.0.0 → 8.2.1 (minor, within 8.x)
- **mockito-scala**: 1.17.37 → 2.0.0 — major bump; upgrades mockito-core to 5.x, drops JDK 8 (CI uses JDK 17, no impact)
- **testcontainers**: 1.19.3 → 1.21.3 (minor)
- **sbt**: 1.12.2 → 1.12.11 (patch)
- **sbt-scalafmt**: 2.5.6 → 2.6.1 (minor)

`scalatest` and `sbt-ci-release` already at latest stable. Scala 2.12.21 unchanged (latest for 2.12.x).

> **Note on mockito-scala 2.x:** 2.0.0 is the last version publishing `_2.12` artifacts — 2.1.0+ dropped Scala 2.12 support. The API is compatible; only internal mockito-core upgraded from 4.x to 5.x.

Also updates `AGENTS.md`: syncs all version references and documents `it:test` command for integration tests.

## Test plan

- [ ] `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
- [ ] `sbt it:test` (requires Docker)
- [ ] `sbt scripted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)