### PR TITLE
refactor(build): modernize build, restore integration tests, dedupe CI

### DIFF
--- a/.github/actions/sbt-setup/action.yml
+++ b/.github/actions/sbt-setup/action.yml
@@ -1,0 +1,25 @@
+name: 'sbt setup'
+description: 'Set up Temurin JDK, sbt, and dependency caches for an sbt build'
+inputs:
+  java-version:
+    description: 'Temurin JDK version'
+    required: false
+    default: '17'
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+        cache: sbt
+    - uses: sbt/setup-sbt@v1
+    - uses: coursier/cache-action@v8
+    - uses: actions/cache@v5
+      with:
+        path: |
+          ~/.ivy2/cache
+          ~/.sbt
+          ~/.cache/coursier
+        key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+        restore-keys: sbt-${{ runner.os }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ concurrency:
 env:
   SBT_OPTS: -Dsbt.color=true -Dsbt.log.noformat=false -Dsbt.supershell=false
   JAVA_OPTS: -Xms2G -Xmx2G -Xss4M -XX:+UseG1GC
-  JVM_OPTS: -Xms2G -Xmx2G -Xss4M -XX:+UseG1GC
   FORCE_COLOR: "1"
   TERM: xterm-256color
 
@@ -29,13 +28,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: sbt
-      - uses: sbt/setup-sbt@v1
-      - uses: coursier/cache-action@v8
+      - uses: ./.github/actions/sbt-setup
       - run: sbt scalafmtCheckAll scalafmtSbtCheck
 
   test:
@@ -46,25 +39,23 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: sbt
-      - uses: sbt/setup-sbt@v1
-      - uses: coursier/cache-action@v8
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.cache/coursier
-          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
-          restore-keys: sbt-${{ runner.os }}-
+      - uses: ./.github/actions/sbt-setup
       - name: Compile
         run: sbt compile
       - name: Test
         run: sbt test
+
+  it-test:
+    name: Integration Test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/sbt-setup
+      - name: Integration Test
+        run: sbt it/test
 
   release:
     name: Release (tag-driven)
@@ -78,21 +69,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: sbt
-      - uses: sbt/setup-sbt@v1
-      - uses: coursier/cache-action@v8
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.cache/coursier
-          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
-          restore-keys: sbt-${{ runner.os }}-
+      - uses: ./.github/actions/sbt-setup
       - name: Compute next version & create tag on main
         id: bump
         if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ version number instead:
 RegistrySubject("subject", 4)   // always downloads version 4
 ```
 
+## Development
+
+Built with **sbt 1.12.11** on **Scala 2.12.21** (the Scala version sbt runs on). The build is split into two
+modules: the plugin itself (root) and an `it` subproject that holds the Testcontainers-based integration tests.
+
+```bash
+sbt scalafmtAll scalafmtSbt   # format
+sbt compile test              # compile + unit tests (no external services)
+sbt it/test                   # integration tests — spins up Schema Registry + Kafka, requires Docker
+```
+
+CI runs formatting, unit tests, and integration tests on every PR; releases are tag-driven and published to
+Maven Central via `sbt-ci-release`.
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/build.sbt
+++ b/build.sbt
@@ -1,35 +1,53 @@
 import Dependencies.*
 
+val sbtV = "1.12.11"
+
+lazy val commonSettings = Seq(
+  scalaVersion := "2.12.21",
+  scalacOptions ++= Seq(
+    "-encoding",
+    "UTF-8",
+    "-Xfatal-warnings",
+    "-deprecation",
+    "-feature",
+    "-unchecked",
+    "-language:implicitConversions",
+    "-language:higherKinds",
+    "-language:existentials",
+    "-language:postfixOps",
+  ),
+)
+
 lazy val sbtSchemaRegistryPlugin = (project in file("."))
   .enablePlugins(SbtPlugin, GitVersioning)
-  .configs(IntegrationTest)
+  .settings(commonSettings)
   .settings(
     name                          := "sbt-schema-registry-plugin",
-    scalaVersion                  := "2.12.21",
     sbtPlugin                     := true,
-    pluginCrossBuild / sbtVersion := "1.12.2",
+    pluginCrossBuild / sbtVersion := sbtV,
     resolvers ++= Seq("Confluent" at "https://packages.confluent.io/maven/"),
-    libraryDependencies ++= Seq(schemaRegistryClient, scalatest, mockitoScala),
+    libraryDependencies ++= Seq(
+      schemaRegistryClient,
+      scalatest    % Test,
+      mockitoScala % Test,
+    ),
     scriptedLaunchOpts ++= Seq(
       "-Xmx1024M",
       "-Dplugin.version=" + version.value,
     ),
     scriptedBufferLog             := false,
-    scalacOptions ++= Seq(
-      "-encoding",
-      "UTF-8",            // Option and arguments on same line
-      "-Xfatal-warnings", // New lines for each options
-      "-deprecation",
-      "-feature",
-      "-unchecked",
-      "-language:implicitConversions",
-      "-language:higherKinds",
-      "-language:existentials",
-      "-language:postfixOps",
-    ),
   )
+
+lazy val it = (project in file("it"))
+  .dependsOn(sbtSchemaRegistryPlugin)
+  .settings(commonSettings)
   .settings(
-    inConfig(IntegrationTest)(Defaults.itSettings),
-    IntegrationTest / fork := true,
-    libraryDependencies ++= Seq(testcontainersKafka),
+    name           := "sbt-schema-registry-plugin-it",
+    publish / skip := true,
+    Test / fork    := true,
+    libraryDependencies ++= Seq(
+      "org.scala-sbt"    %% "util-logging" % sbtV % Test,
+      scalatest           % Test,
+      testcontainersKafka % Test,
+    ),
   )

--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -6,8 +6,9 @@ import org.apache.avro.Schema
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, KafkaContainer, Network}
+import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
 import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
 import org.testcontainers.utility.DockerImageName
 import sbt.util.Logger
 
@@ -16,12 +17,12 @@ import scala.util.{Failure, Success}
 
 /** Integration tests for [[Downloader]] using real Confluent Schema Registry and Kafka containers.
   *
-  * Run with: sbt IntegrationTest/test (requires Docker)
+  * Run with: sbt it/test (requires Docker)
   */
 class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   private var network: Network                           = _
-  private var kafka: KafkaContainer                      = _
+  private var kafka: ConfluentKafkaContainer             = _
   private var sr: JGenericContainer[_]                   = _
   private var registryUrl: String                        = _
   private var registryClient: CachedSchemaRegistryClient = _
@@ -29,16 +30,16 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
   override def beforeAll(): Unit = {
     network = Network.newNetwork()
 
-    kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+    kafka.withListener("kafka:19092")
     kafka.withNetwork(network)
-    kafka.withNetworkAliases("kafka")
     kafka.start()
 
     sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
     sr.withNetwork(network)
     sr.withExposedPorts(8081)
     sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "kafka:9092")
+    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
     sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
     sr.start()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,15 +2,11 @@ import sbt.*
 
 object Dependencies {
   private object Versions {
-    val avro           = "1.12.1"
     val schReqClient   = "8.2.1"
     val scalatest      = "3.2.19"
     val mockito        = "2.0.0"
     val testcontainers = "1.21.3"
   }
-
-  lazy val avroCompiler: ModuleID = "org.apache.avro" % "avro-compiler" % Versions.avro
-  lazy val avroCore: ModuleID     = "org.apache.avro" % "avro"          % Versions.avro
 
   lazy val schemaRegistryClient: ModuleID = "io.confluent" % "kafka-schema-registry-client" % Versions.schReqClient
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,9 +10,8 @@ object Dependencies {
 
   lazy val schemaRegistryClient: ModuleID = "io.confluent" % "kafka-schema-registry-client" % Versions.schReqClient
 
-  lazy val scalatest: ModuleID    = "org.scalatest" %% "scalatest"               % Versions.scalatest % Test
-  lazy val mockitoScala: ModuleID = "org.mockito"   %% "mockito-scala-scalatest" % Versions.mockito   % Test
+  lazy val scalatest: ModuleID    = "org.scalatest" %% "scalatest"               % Versions.scalatest
+  lazy val mockitoScala: ModuleID = "org.mockito"   %% "mockito-scala-scalatest" % Versions.mockito
 
-  lazy val testcontainersKafka: ModuleID =
-    "org.testcontainers" % "kafka" % Versions.testcontainers % IntegrationTest
+  lazy val testcontainersKafka: ModuleID = "org.testcontainers" % "kafka" % Versions.testcontainers
 }


### PR DESCRIPTION
## Summary

Modernizes the build and **restores the integration tests**, which never compiled on `main` (scalatest was outside the `IntegrationTest` scope, and testcontainers 1.21 deprecated `KafkaContainer` under `-Xfatal-warnings`).

Split into four semantic, individually-green commits.

## Commits

1. **chore(deps): remove unused avro dependencies** — `avroCompiler`/`avroCore` were declared but never wired into `libraryDependencies`; Avro types reach the tests transitively via the schema-registry client.
2. **refactor(build): move integration tests to dedicated `it` subproject** — replaces the sbt 1.9-deprecated `IntegrationTest` config (a blocker for sbt 2.x) with a standalone `it` subproject that pulls `sbt.util.Logger` via `org.scala-sbt:util-logging`; aligns the cross-built `sbtVersion` with `build.properties` (1.12.11) via a shared `sbtV`; hoists `scalaVersion`/`scalacOptions` into `commonSettings`; migrates `KafkaContainer` → `ConfluentKafkaContainer` (`withListener`).
3. **ci: extract sbt setup into composite action and run integration tests** — factors the repeated checkout/JDK/sbt/cache steps into `.github/actions/sbt-setup`; adds an `it-test` job (`sbt it/test`); drops the redundant `JVM_OPTS` env (sbt reads `JAVA_OPTS`).
4. **docs: document development workflow and build layout in README**.

## Validation

Each commit verified green:

- `sbt scalafmtCheckAll scalafmtSbtCheck compile test` — 9/9 unit, 0 warnings
- `sbt it/test` — 5/5 integration (Testcontainers Schema Registry + Kafka, Docker)

## Notes

- `release` job intentionally keeps `needs: [format, test]` — integration tests run on every PR but do not gate Sonatype publish, avoiding transient Docker-pull flake blocking a tag release. Enforce `it-test` via branch protection if release-time gating is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)