### PR TITLE
fix(build): use console-git runner so worktree builds load

### DIFF
--- a/publish.sbt
+++ b/publish.sbt
@@ -1,3 +1,8 @@
+import com.github.sbt.git.SbtGit
+
+// Use the git CLI instead of jgit for repo reads — jgit throws NoWorkTreeException in git worktrees.
+SbtGit.useReadableConsoleGit
+
 ThisBuild / versionScheme        := Some("semver-spec")
 ThisBuild / organization         := "org.galaxio"
 ThisBuild / organizationName     := "Galaxio Team"


### PR DESCRIPTION
jgit (via sbt-git, pulled in by sbt-ci-release) throws `NoWorkTreeException` inside a git worktree — a linked worktree's `.git` is a file, not a dir. `SbtGit.useReadableConsoleGit` reads git state via the `git` CLI, which is worktree-aware.

Verified in a worktree: loads, `compile test` (9 unit tests) pass, scalafmt clean, version still dynver-derived.