### PR TITLE
fix: close CachedSchemaRegistryClient after use

### DIFF
--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -8,7 +8,13 @@ import java.util.{Collections, HashMap => JHashMap}
 import scala.util.Try
 import sbt.util.Logger
 
-class Downloader(client: SchemaRegistryClient, schemaOutputDir: Path, logger: Logger) {
+class Downloader private (client: SchemaRegistryClient, schemaOutputDir: Path, logger: Logger, closeAction: () => Unit)
+    extends AutoCloseable {
+
+  def this(client: SchemaRegistryClient, schemaOutputDir: Path, logger: Logger) =
+    this(client, schemaOutputDir, logger, () => ())
+
+  override def close(): Unit = closeAction()
 
   private def createOutputDirIfNeeded(): Unit =
     if (Files.notExists(schemaOutputDir))
@@ -64,6 +70,6 @@ object Downloader {
       if (config.isEmpty) new CachedSchemaRegistryClient(rootUrl, cacheSize)
       else new CachedSchemaRegistryClient(Collections.singletonList(rootUrl), cacheSize, config)
 
-    new Downloader(client, schemaOutputDir, logger)
+    new Downloader(client, schemaOutputDir, logger, () => client.close())
   }
 }

--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -14,7 +14,9 @@ class Downloader private (client: SchemaRegistryClient, schemaOutputDir: Path, l
   def this(client: SchemaRegistryClient, schemaOutputDir: Path, logger: Logger) =
     this(client, schemaOutputDir, logger, () => ())
 
-  override def close(): Unit = closeAction()
+  override def close(): Unit =
+    try closeAction()
+    catch { case e: Exception => logger.warn(s"Failed to close schema registry client: ${e.getMessage}") }
 
   private def createOutputDirIfNeeded(): Unit =
     if (Files.notExists(schemaOutputDir))

--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -15,8 +15,7 @@ class Downloader private (client: SchemaRegistryClient, schemaOutputDir: Path, l
     this(client, schemaOutputDir, logger, () => ())
 
   override def close(): Unit =
-    try closeAction()
-    catch { case e: Exception => logger.warn(s"Failed to close schema registry client: ${e.getMessage}") }
+    Try(closeAction()).failed.foreach(e => logger.warn(s"Failed to close schema registry client: ${e.getMessage}"))
 
   private def createOutputDirIfNeeded(): Unit =
     if (Files.notExists(schemaOutputDir))

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -3,6 +3,8 @@ package org.galaxio.avro
 import sbt.*
 import Keys.*
 
+import scala.util.Using
+
 object SchemaDownloaderPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
@@ -40,16 +42,16 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       if (subjects.isEmpty) {
         logger.warn("No schema subjects configured. Set schemaRegistrySubjects to download schemas.")
       } else {
-        val downloader = Downloader(
-          rootUrl = schemaRegistryUrl.value,
-          schemaOutputDir = schemaRegistryTargetFolder.value.toPath,
-          logger = logger,
-          cacheSize = schemaRegistryCacheSize.value,
-          auth = schemaRegistryAuth.value,
-          properties = schemaRegistryProperties.value,
-        )
-
-        try {
+        Using.resource(
+          Downloader(
+            rootUrl = schemaRegistryUrl.value,
+            schemaOutputDir = schemaRegistryTargetFolder.value.toPath,
+            logger = logger,
+            cacheSize = schemaRegistryCacheSize.value,
+            auth = schemaRegistryAuth.value,
+            properties = schemaRegistryProperties.value,
+          ),
+        ) { downloader =>
           val results  = subjects.map(s => s -> downloader.schemaSubjectToFile(s))
           val failures = results.collect { case (s, scala.util.Failure(e)) => s -> e }
 
@@ -60,8 +62,6 @@ object SchemaDownloaderPlugin extends AutoPlugin {
             }
             sys.error(s"Failed to download ${failures.size} schema(s)")
           }
-        } finally {
-          downloader.close()
         }
       }
     },

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -49,15 +49,19 @@ object SchemaDownloaderPlugin extends AutoPlugin {
           properties = schemaRegistryProperties.value,
         )
 
-        val results  = subjects.map(s => s -> downloader.schemaSubjectToFile(s))
-        val failures = results.collect { case (s, scala.util.Failure(e)) => s -> e }
+        try {
+          val results  = subjects.map(s => s -> downloader.schemaSubjectToFile(s))
+          val failures = results.collect { case (s, scala.util.Failure(e)) => s -> e }
 
-        if (failures.nonEmpty) {
-          failures.foreach { case (s, e) =>
-            logger.error(s"Failed to download schema ${s.name}: ${e.getMessage}")
-            logger.trace(e)
+          if (failures.nonEmpty) {
+            failures.foreach { case (s, e) =>
+              logger.error(s"Failed to download schema ${s.name}: ${e.getMessage}")
+              logger.trace(e)
+            }
+            sys.error(s"Failed to download ${failures.size} schema(s)")
           }
-          sys.error(s"Failed to download ${failures.size} schema(s)")
+        } finally {
+          downloader.close()
         }
       }
     },


### PR DESCRIPTION
## Summary
- `Downloader` now implements `AutoCloseable` with ownership tracking
- Factory-created clients (`Downloader.apply`) close the underlying `CachedSchemaRegistryClient`
- Test-injected mocks (public 3-arg constructor) default to no-op close — tests own their mocks
- Plugin task wraps downloader usage in `try/finally` to prevent connection/FD leaks in long-lived sbt JVM

## Test plan
- [x] 9 unit tests pass (existing mock-based tests use public constructor → no-op close)
- [ ] `it/test` (integration, Docker) — verify real client closes cleanly
- [ ] `sbt scripted` — plugin e2e still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)