### PR TITLE
test: add auth and properties wiring unit tests (U-07/U-08)

### DIFF
--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -51,6 +51,19 @@ class Downloader private (client: SchemaRegistryClient, schemaOutputDir: Path, l
 object Downloader {
   val avroSchemaFileExtension = "avsc"
 
+  private[avro] def buildConfig(
+      auth: Option[SchemaRegistryAuth],
+      properties: Map[String, String],
+  ): JHashMap[String, Any] = {
+    val config = new JHashMap[String, Any]()
+    properties.foreach { case (k, v) => config.put(k, v) }
+    auth.foreach { case SchemaRegistryAuth.BasicAuth(user, pass) =>
+      config.put("basic.auth.credentials.source", "USER_INFO")
+      config.put("basic.auth.user.info", s"$user:$pass")
+    }
+    config
+  }
+
   def apply(
       rootUrl: String,
       schemaOutputDir: Path,
@@ -59,13 +72,7 @@ object Downloader {
       auth: Option[SchemaRegistryAuth] = None,
       properties: Map[String, String] = Map.empty,
   ): Downloader = {
-    val config = new JHashMap[String, Any]()
-    properties.foreach { case (k, v) => config.put(k, v) }
-
-    auth.foreach { case SchemaRegistryAuth.BasicAuth(user, pass) =>
-      config.put("basic.auth.credentials.source", "USER_INFO")
-      config.put("basic.auth.user.info", s"$user:$pass")
-    }
+    val config = buildConfig(auth, properties)
 
     val client =
       if (config.isEmpty) new CachedSchemaRegistryClient(rootUrl, cacheSize)

--- a/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
@@ -110,4 +110,45 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     Files.exists(dir.resolve("my.schema-3.avsc")) shouldBe true
   }
 
+  "Downloader.buildConfig" should "set BasicAuth credentials" in {
+    val config = Downloader.buildConfig(
+      Some(SchemaRegistryAuth.BasicAuth("alice", "s3cret")),
+      Map.empty,
+    )
+
+    config.get("basic.auth.credentials.source") shouldBe "USER_INFO"
+    config.get("basic.auth.user.info") shouldBe "alice:s3cret"
+  }
+
+  it should "pass through arbitrary properties unchanged" in {
+    val config = Downloader.buildConfig(
+      None,
+      Map(
+        "schema.registry.ssl.truststore.location" -> "/etc/pki/trust.jks",
+        "schema.registry.ssl.truststore.password" -> "changeit",
+      ),
+    )
+
+    config.get("schema.registry.ssl.truststore.location") shouldBe "/etc/pki/trust.jks"
+    config.get("schema.registry.ssl.truststore.password") shouldBe "changeit"
+    config.size() shouldBe 2
+  }
+
+  it should "merge auth and properties without key loss" in {
+    val config = Downloader.buildConfig(
+      Some(SchemaRegistryAuth.BasicAuth("bob", "pw")),
+      Map("custom.prop" -> "val"),
+    )
+
+    config.get("basic.auth.credentials.source") shouldBe "USER_INFO"
+    config.get("basic.auth.user.info") shouldBe "bob:pw"
+    config.get("custom.prop") shouldBe "val"
+    config.size() shouldBe 3
+  }
+
+  it should "return empty map when no auth and no properties" in {
+    val config = Downloader.buildConfig(None, Map.empty)
+    config shouldBe empty
+  }
+
 }


### PR DESCRIPTION
## Summary
- Extract `Downloader.buildConfig` as a `private[avro]` pure function for testability
- **U-07**: BasicAuth wiring — verifies `USER_INFO` source + `user:pass` config entry
- **U-08**: Properties passthrough — arbitrary properties reach client config unchanged; auth + properties merge without key loss; empty config stays empty

## Test plan
- [x] 13 unit tests pass (9 existing + 4 new)
- [ ] `it/test` — integration tests still green
- [ ] `sbt scripted` — plugin e2e still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)