### PR TITLE
test(scripted): add compile hook e2e tests (E2E-04/E2E-05)

### DIFF
--- a/src/sbt-test/schema-registry/hook-compile/build.sbt
+++ b/src/sbt-test/schema-registry/hook-compile/build.sbt
@@ -1,0 +1,11 @@
+import org.galaxio.avro.RegistrySubject
+
+// Hook download into compile via dependsOn.
+// Registry is unreachable — if compile fails, the hook fired.
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion           := "2.12.21",
+    schemaRegistryUrl      := "http://127.0.0.1:1",
+    schemaRegistrySubjects += RegistrySubject("hook-test", 1),
+    Compile / compile      := (Compile / compile).dependsOn(Compile / schemaRegistryDownload).value,
+  )

--- a/src/sbt-test/schema-registry/hook-compile/project/plugins.sbt
+++ b/src/sbt-test/schema-registry/hook-compile/project/plugins.sbt
@@ -1,0 +1,6 @@
+resolvers ++= Seq("Confluent" at "https://packages.confluent.io/maven/")
+
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("org.galaxio" % "sbt-schema-registry-plugin" % v)
+  case None    => sys.error("plugin.version system property not set (provided by scriptedLaunchOpts)")
+}

--- a/src/sbt-test/schema-registry/hook-compile/test
+++ b/src/sbt-test/schema-registry/hook-compile/test
@@ -1,0 +1,3 @@
+# compile must trigger schemaRegistryDownload via dependsOn.
+# Registry is unreachable, so compile must fail — proving the hook fired.
+-> compile

--- a/src/sbt-test/schema-registry/hook-source-generators/build.sbt
+++ b/src/sbt-test/schema-registry/hook-source-generators/build.sbt
@@ -1,0 +1,14 @@
+import org.galaxio.avro.RegistrySubject
+
+// Hook download into sourceGenerators.
+// Registry is unreachable — if compile fails, the hook fired.
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion           := "2.12.21",
+    schemaRegistryUrl      := "http://127.0.0.1:1",
+    schemaRegistrySubjects += RegistrySubject("hook-test", 1),
+    Compile / sourceGenerators += Def.task {
+      (Compile / schemaRegistryDownload).value
+      Seq.empty[File]
+    }.taskValue,
+  )

--- a/src/sbt-test/schema-registry/hook-source-generators/project/plugins.sbt
+++ b/src/sbt-test/schema-registry/hook-source-generators/project/plugins.sbt
@@ -1,0 +1,6 @@
+resolvers ++= Seq("Confluent" at "https://packages.confluent.io/maven/")
+
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("org.galaxio" % "sbt-schema-registry-plugin" % v)
+  case None    => sys.error("plugin.version system property not set (provided by scriptedLaunchOpts)")
+}

--- a/src/sbt-test/schema-registry/hook-source-generators/test
+++ b/src/sbt-test/schema-registry/hook-source-generators/test
@@ -1,0 +1,3 @@
+# compile must trigger schemaRegistryDownload via sourceGenerators.
+# Registry is unreachable, so compile must fail — proving the hook fired.
+-> compile


### PR DESCRIPTION
## Summary
- **E2E-04** `hook-compile`: proves `Compile / compile := ... .dependsOn(Compile / schemaRegistryDownload).value` wiring works — compile triggers download
- **E2E-05** `hook-source-generators`: proves `sourceGenerators += Def.task { (Compile / schemaRegistryDownload).value; Seq.empty[File] }.taskValue` wiring works — compile triggers download

Both use an unreachable registry (`127.0.0.1:1`) to assert compile fails, proving the hook fired.

## Test plan
- [x] `scripted schema-registry/hook-compile` — pass
- [x] `scripted schema-registry/hook-source-generators` — pass
- [x] Existing scripted tests still green (empty-subjects, download-failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)