### PR TITLE
refactor: idiomatic FP rewrite + remaining tests

### DIFF
--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -15,12 +15,8 @@ import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import java.util.Collections
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
-/** Integration tests for [[Downloader]] using real Confluent Schema Registry and Kafka containers.
-  *
-  * Run with: sbt it/test (requires Docker)
-  */
 class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   private var network: Network                           = _
@@ -50,16 +46,16 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
   }
 
   override def afterAll(): Unit = {
-    try { if (sr != null) sr.stop() }
-    catch { case _: Exception => }
-    try { if (kafka != null) kafka.stop() }
-    catch { case _: Exception => }
-    try { if (network != null) network.close() }
-    catch { case _: Exception => }
+    Option(sr).foreach(c => Try(c.stop()))
+    Option(kafka).foreach(c => Try(c.stop()))
+    Option(network).foreach(c => Try(c.close()))
   }
 
   private def avroSchema(json: String): AvroSchema =
     new AvroSchema(new Schema.Parser().parse(json))
+
+  private def readFile(path: Path): String =
+    new String(Files.readAllBytes(path))
 
   private val silentLogger: Logger = Logger.Null
 
@@ -73,54 +69,53 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     try test(downloader)
     finally downloader.close()
 
-  "Downloader (integration)" should "download schema by specific version" in withTempDir { dir =>
+  private def withFixture(test: (Path, Downloader) => Any): Unit =
+    withTempDir { dir =>
+      withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+        test(dir, downloader)
+      }
+    }
+
+  "Downloader (integration)" should "download schema by specific version" in withFixture { (dir, downloader) =>
     val subject    = "it-specific"
     val schemaJson =
       """{"type":"record","name":"ItSpecific","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
-      val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
+    val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-      result shouldBe a[Success[_]]
-      val file = dir.resolve(s"$subject-1.avsc")
-      Files.exists(file) shouldBe true
-      new String(Files.readAllBytes(file)) shouldBe schemaJson
-    }
+    result shouldBe a[Success[_]]
+    val file = dir.resolve(s"$subject-1.avsc")
+    Files.exists(file) shouldBe true
+    readFile(file) shouldBe schemaJson
   }
 
-  it should "download latest schema version and write versioned filename" in withTempDir { dir =>
+  it should "download latest schema version and write versioned filename" in withFixture { (dir, downloader) =>
     val subject    = "it-latest"
     val schemaJson = """{"type":"record","name":"ItLatest","namespace":"org.galaxio","fields":[{"name":"v","type":"string"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
-      val result = downloader.schemaSubjectToFile(RegistrySubject.latest(subject))
+    val result = downloader.schemaSubjectToFile(RegistrySubject.latest(subject))
 
-      result shouldBe a[Success[_]]
-      val file = dir.resolve(s"$subject-1.avsc")
-      Files.exists(file) shouldBe true
-      new String(Files.readAllBytes(file)) shouldBe schemaJson
-    }
+    result shouldBe a[Success[_]]
+    val file = dir.resolve(s"$subject-1.avsc")
+    Files.exists(file) shouldBe true
+    readFile(file) shouldBe schemaJson
   }
 
-  it should "return Failure for missing subject" in withTempDir { dir =>
-    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
-      val result = downloader.schemaSubjectToFile(RegistrySubject("does-not-exist", 1))
-      result shouldBe a[Failure[_]]
-    }
+  it should "return Failure for missing subject" in withFixture { (_, downloader) =>
+    val result = downloader.schemaSubjectToFile(RegistrySubject("does-not-exist", 1))
+    result shouldBe a[Failure[_]]
   }
 
-  it should "return Failure for missing version of existing subject" in withTempDir { dir =>
+  it should "return Failure for missing version of existing subject" in withFixture { (_, downloader) =>
     val subject    = "it-version-miss"
     val schemaJson =
       """{"type":"record","name":"ItVersionMiss","namespace":"org.galaxio","fields":[{"name":"x","type":"int"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
-      val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 99))
-      result shouldBe a[Failure[_]]
-    }
+    val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 99))
+    result shouldBe a[Failure[_]]
   }
 
   it should "produce identical output files across two downloads" in withTempDir { dir =>
@@ -140,7 +135,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
 
         r1 shouldBe a[Success[_]]
         r2 shouldBe a[Success[_]]
-        new String(Files.readAllBytes(r1.get)) shouldBe new String(Files.readAllBytes(r2.get))
+        readFile(r1.get) shouldBe readFile(r2.get)
       }
     }
   }
@@ -159,7 +154,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       result shouldBe a[Success[_]]
       val file = dir.resolve(s"$subject-1.avsc")
       Files.exists(file) shouldBe true
-      new String(Files.readAllBytes(file)) shouldBe schemaJson
+      readFile(file) shouldBe schemaJson
     }
   }
 
@@ -181,13 +176,13 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       latestResult shouldBe a[Success[_]]
       val latestFile = dir.resolve(s"$subject-3.avsc")
       Files.exists(latestFile) shouldBe true
-      new String(Files.readAllBytes(latestFile)) shouldBe v3Json
+      readFile(latestFile) shouldBe v3Json
 
       val pinnedResult = downloader.schemaSubjectToFile(RegistrySubject(subject, 2))
       pinnedResult shouldBe a[Success[_]]
       val pinnedFile = dir.resolve(s"$subject-2.avsc")
       Files.exists(pinnedFile) shouldBe true
-      new String(Files.readAllBytes(pinnedFile)) shouldBe v2Json
+      readFile(pinnedFile) shouldBe v2Json
     }
 
     val v4Json =
@@ -201,7 +196,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       latestV4Result shouldBe a[Success[_]]
       val latestV4File = dir2.resolve(s"$subject-4.avsc")
       Files.exists(latestV4File) shouldBe true
-      new String(Files.readAllBytes(latestV4File)) shouldBe v4Json
+      readFile(latestV4File) shouldBe v4Json
     }
   }
 
@@ -224,7 +219,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       result shouldBe a[Success[_]]
       val file = dir.resolve(s"$mainSubject-1.avsc")
       Files.exists(file) shouldBe true
-      new String(Files.readAllBytes(file)) shouldBe mainJson
+      readFile(file) shouldBe mainJson
     }
   }
 
@@ -244,7 +239,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       Files.exists(deepDir) shouldBe true
       val file = deepDir.resolve(s"$subject-1.avsc")
       Files.exists(file) shouldBe true
-      new String(Files.readAllBytes(file)) shouldBe schemaJson
+      readFile(file) shouldBe schemaJson
     }
   }
 
@@ -260,11 +255,11 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
 
       val file = dir.resolve(s"$subject-1.avsc")
       Files.write(file, "corrupted".getBytes())
-      new String(Files.readAllBytes(file)) shouldBe "corrupted"
+      readFile(file) shouldBe "corrupted"
 
       val second = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
       second shouldBe a[Success[_]]
-      new String(Files.readAllBytes(file)) shouldBe schemaJson
+      readFile(file) shouldBe schemaJson
     }
   }
 }

--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -79,12 +79,14 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       """{"type":"record","name":"ItSpecific","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    val result = Downloader(registryUrl, dir, silentLogger).schemaSubjectToFile(RegistrySubject(subject, 1))
+    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+      val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-    result shouldBe a[Success[_]]
-    val file = dir.resolve(s"$subject-1.avsc")
-    Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe schemaJson
+      result shouldBe a[Success[_]]
+      val file = dir.resolve(s"$subject-1.avsc")
+      Files.exists(file) shouldBe true
+      new String(Files.readAllBytes(file)) shouldBe schemaJson
+    }
   }
 
   it should "download latest schema version and write versioned filename" in withTempDir { dir =>
@@ -92,17 +94,21 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     val schemaJson = """{"type":"record","name":"ItLatest","namespace":"org.galaxio","fields":[{"name":"v","type":"string"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    val result = Downloader(registryUrl, dir, silentLogger).schemaSubjectToFile(RegistrySubject.latest(subject))
+    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+      val result = downloader.schemaSubjectToFile(RegistrySubject.latest(subject))
 
-    result shouldBe a[Success[_]]
-    val file = dir.resolve(s"$subject-1.avsc")
-    Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe schemaJson
+      result shouldBe a[Success[_]]
+      val file = dir.resolve(s"$subject-1.avsc")
+      Files.exists(file) shouldBe true
+      new String(Files.readAllBytes(file)) shouldBe schemaJson
+    }
   }
 
   it should "return Failure for missing subject" in withTempDir { dir =>
-    val result = Downloader(registryUrl, dir, silentLogger).schemaSubjectToFile(RegistrySubject("does-not-exist", 1))
-    result shouldBe a[Failure[_]]
+    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+      val result = downloader.schemaSubjectToFile(RegistrySubject("does-not-exist", 1))
+      result shouldBe a[Failure[_]]
+    }
   }
 
   it should "return Failure for missing version of existing subject" in withTempDir { dir =>
@@ -111,8 +117,10 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       """{"type":"record","name":"ItVersionMiss","namespace":"org.galaxio","fields":[{"name":"x","type":"int"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    val result = Downloader(registryUrl, dir, silentLogger).schemaSubjectToFile(RegistrySubject(subject, 99))
-    result shouldBe a[Failure[_]]
+    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+      val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 99))
+      result shouldBe a[Failure[_]]
+    }
   }
 
   it should "produce identical output files across two downloads" in withTempDir { dir =>
@@ -125,12 +133,16 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     Files.createDirectories(dir1)
     Files.createDirectories(dir2)
 
-    val r1 = Downloader(registryUrl, dir1, silentLogger).schemaSubjectToFile(RegistrySubject(subject, 1))
-    val r2 = Downloader(registryUrl, dir2, silentLogger).schemaSubjectToFile(RegistrySubject(subject, 1))
+    withDownloader(Downloader(registryUrl, dir1, silentLogger)) { d1 =>
+      withDownloader(Downloader(registryUrl, dir2, silentLogger)) { d2 =>
+        val r1 = d1.schemaSubjectToFile(RegistrySubject(subject, 1))
+        val r2 = d2.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-    r1 shouldBe a[Success[_]]
-    r2 shouldBe a[Success[_]]
-    new String(Files.readAllBytes(r1.get)) shouldBe new String(Files.readAllBytes(r2.get))
+        r1 shouldBe a[Success[_]]
+        r2 shouldBe a[Success[_]]
+        new String(Files.readAllBytes(r1.get)) shouldBe new String(Files.readAllBytes(r2.get))
+      }
+    }
   }
 
   it should "download successfully when BasicAuth is configured against non-auth registry" in withTempDir { dir =>
@@ -225,13 +237,15 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     val deepDir = dir.resolve("nested").resolve("deep").resolve("output")
     Files.exists(deepDir) shouldBe false
 
-    val result = Downloader(registryUrl, deepDir, silentLogger).schemaSubjectToFile(RegistrySubject(subject, 1))
+    withDownloader(Downloader(registryUrl, deepDir, silentLogger)) { downloader =>
+      val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-    result shouldBe a[Success[_]]
-    Files.exists(deepDir) shouldBe true
-    val file = deepDir.resolve(s"$subject-1.avsc")
-    Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe schemaJson
+      result shouldBe a[Success[_]]
+      Files.exists(deepDir) shouldBe true
+      val file = deepDir.resolve(s"$subject-1.avsc")
+      Files.exists(file) shouldBe true
+      new String(Files.readAllBytes(file)) shouldBe schemaJson
+    }
   }
 
   it should "overwrite corrupted file on re-download" in withTempDir { dir =>

--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -69,6 +69,10 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     finally Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
   }
 
+  private def withDownloader(downloader: Downloader)(test: Downloader => Any): Unit =
+    try test(downloader)
+    finally downloader.close()
+
   "Downloader (integration)" should "download schema by specific version" in withTempDir { dir =>
     val subject    = "it-specific"
     val schemaJson =
@@ -135,14 +139,16 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       """{"type":"record","name":"ItBasicAuth","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    val downloader =
-      Downloader(registryUrl, dir, silentLogger, auth = Some(SchemaRegistryAuth.BasicAuth("user", "pass")))
-    val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
+    withDownloader(
+      Downloader(registryUrl, dir, silentLogger, auth = Some(SchemaRegistryAuth.BasicAuth("user", "pass"))),
+    ) { downloader =>
+      val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-    result shouldBe a[Success[_]]
-    val file = dir.resolve(s"$subject-1.avsc")
-    Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe schemaJson
+      result shouldBe a[Success[_]]
+      val file = dir.resolve(s"$subject-1.avsc")
+      Files.exists(file) shouldBe true
+      new String(Files.readAllBytes(file)) shouldBe schemaJson
+    }
   }
 
   it should "track multi-version evolution and download latest or pinned" in withTempDir { dir =>
@@ -158,32 +164,33 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     registryClient.register(subject, avroSchema(v2Json))
     registryClient.register(subject, avroSchema(v3Json))
 
-    val downloader = Downloader(registryUrl, dir, silentLogger)
+    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+      val latestResult = downloader.schemaSubjectToFile(RegistrySubject.latest(subject))
+      latestResult shouldBe a[Success[_]]
+      val latestFile = dir.resolve(s"$subject-3.avsc")
+      Files.exists(latestFile) shouldBe true
+      new String(Files.readAllBytes(latestFile)) shouldBe v3Json
 
-    val latestResult = downloader.schemaSubjectToFile(RegistrySubject.latest(subject))
-    latestResult shouldBe a[Success[_]]
-    val latestFile = dir.resolve(s"$subject-3.avsc")
-    Files.exists(latestFile) shouldBe true
-    new String(Files.readAllBytes(latestFile)) shouldBe v3Json
-
-    val pinnedResult = downloader.schemaSubjectToFile(RegistrySubject(subject, 2))
-    pinnedResult shouldBe a[Success[_]]
-    val pinnedFile = dir.resolve(s"$subject-2.avsc")
-    Files.exists(pinnedFile) shouldBe true
-    new String(Files.readAllBytes(pinnedFile)) shouldBe v2Json
+      val pinnedResult = downloader.schemaSubjectToFile(RegistrySubject(subject, 2))
+      pinnedResult shouldBe a[Success[_]]
+      val pinnedFile = dir.resolve(s"$subject-2.avsc")
+      Files.exists(pinnedFile) shouldBe true
+      new String(Files.readAllBytes(pinnedFile)) shouldBe v2Json
+    }
 
     val v4Json =
       """{"type":"record","name":"Evolve","namespace":"org.galaxio","fields":[{"name":"id","type":"long"},{"name":"name","type":["null","string"],"default":null},{"name":"ts","type":["null","long"],"default":null},{"name":"tag","type":["null","string"],"default":null}]}"""
     registryClient.register(subject, avroSchema(v4Json))
 
-    val dir2           = dir.resolve("latest2")
+    val dir2 = dir.resolve("latest2")
     Files.createDirectories(dir2)
-    val downloader2    = Downloader(registryUrl, dir2, silentLogger)
-    val latestV4Result = downloader2.schemaSubjectToFile(RegistrySubject.latest(subject))
-    latestV4Result shouldBe a[Success[_]]
-    val latestV4File = dir2.resolve(s"$subject-4.avsc")
-    Files.exists(latestV4File) shouldBe true
-    new String(Files.readAllBytes(latestV4File)) shouldBe v4Json
+    withDownloader(Downloader(registryUrl, dir2, silentLogger)) { downloader2 =>
+      val latestV4Result = downloader2.schemaSubjectToFile(RegistrySubject.latest(subject))
+      latestV4Result shouldBe a[Success[_]]
+      val latestV4File = dir2.resolve(s"$subject-4.avsc")
+      Files.exists(latestV4File) shouldBe true
+      new String(Files.readAllBytes(latestV4File)) shouldBe v4Json
+    }
   }
 
   it should "download schema registered with references" in withTempDir { dir =>
@@ -199,13 +206,14 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     val mainSchema  = new AvroSchema(mainJson, Collections.singletonList(ref), Collections.emptyMap[String, String](), null)
     registryClient.register(mainSubject, mainSchema)
 
-    val downloader = Downloader(registryUrl, dir, silentLogger)
-    val result     = downloader.schemaSubjectToFile(RegistrySubject.latest(mainSubject))
+    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+      val result = downloader.schemaSubjectToFile(RegistrySubject.latest(mainSubject))
 
-    result shouldBe a[Success[_]]
-    val file = dir.resolve(s"$mainSubject-1.avsc")
-    Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe mainJson
+      result shouldBe a[Success[_]]
+      val file = dir.resolve(s"$mainSubject-1.avsc")
+      Files.exists(file) shouldBe true
+      new String(Files.readAllBytes(file)) shouldBe mainJson
+    }
   }
 
   it should "auto-create deeply nested output directory" in withTempDir { dir =>
@@ -232,16 +240,17 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       """{"type":"record","name":"ItOverwrite","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
     registryClient.register(subject, avroSchema(schemaJson))
 
-    val downloader = Downloader(registryUrl, dir, silentLogger)
-    val first      = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
-    first shouldBe a[Success[_]]
+    withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
+      val first = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
+      first shouldBe a[Success[_]]
 
-    val file = dir.resolve(s"$subject-1.avsc")
-    Files.write(file, "corrupted".getBytes())
-    new String(Files.readAllBytes(file)) shouldBe "corrupted"
+      val file = dir.resolve(s"$subject-1.avsc")
+      Files.write(file, "corrupted".getBytes())
+      new String(Files.readAllBytes(file)) shouldBe "corrupted"
 
-    val second = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
-    second shouldBe a[Success[_]]
-    new String(Files.readAllBytes(file)) shouldBe schemaJson
+      val second = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
+      second shouldBe a[Success[_]]
+      new String(Files.readAllBytes(file)) shouldBe schemaJson
+    }
   }
 }

--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -15,7 +15,7 @@ import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import java.util.Collections
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
@@ -84,7 +84,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
 
     val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-    result shouldBe a[Success[_]]
+    result shouldBe a[Right[_, _]]
     val file = dir.resolve(s"$subject-1.avsc")
     Files.exists(file) shouldBe true
     readFile(file) shouldBe schemaJson
@@ -97,25 +97,28 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
 
     val result = downloader.schemaSubjectToFile(RegistrySubject.latest(subject))
 
-    result shouldBe a[Success[_]]
+    result shouldBe a[Right[_, _]]
     val file = dir.resolve(s"$subject-1.avsc")
     Files.exists(file) shouldBe true
     readFile(file) shouldBe schemaJson
   }
 
-  it should "return Failure for missing subject" in withFixture { (_, downloader) =>
+  it should "return Left with SchemaFetchFailed for missing subject" in withFixture { (_, downloader) =>
     val result = downloader.schemaSubjectToFile(RegistrySubject("does-not-exist", 1))
-    result shouldBe a[Failure[_]]
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
   }
 
-  it should "return Failure for missing version of existing subject" in withFixture { (_, downloader) =>
-    val subject    = "it-version-miss"
-    val schemaJson =
-      """{"type":"record","name":"ItVersionMiss","namespace":"org.galaxio","fields":[{"name":"x","type":"int"}]}"""
-    registryClient.register(subject, avroSchema(schemaJson))
+  it should "return Left with SchemaFetchFailed for missing version of existing subject" in withFixture {
+    (_, downloader) =>
+      val subject    = "it-version-miss"
+      val schemaJson =
+        """{"type":"record","name":"ItVersionMiss","namespace":"org.galaxio","fields":[{"name":"x","type":"int"}]}"""
+      registryClient.register(subject, avroSchema(schemaJson))
 
-    val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 99))
-    result shouldBe a[Failure[_]]
+      val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 99))
+      result shouldBe a[Left[_, _]]
+      result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
   }
 
   it should "produce identical output files across two downloads" in withTempDir { dir =>
@@ -133,9 +136,10 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
         val r1 = d1.schemaSubjectToFile(RegistrySubject(subject, 1))
         val r2 = d2.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-        r1 shouldBe a[Success[_]]
-        r2 shouldBe a[Success[_]]
-        readFile(r1.get) shouldBe readFile(r2.get)
+        (r1, r2) match {
+          case (Right(p1), Right(p2)) => readFile(p1) shouldBe readFile(p2)
+          case _                      => fail("Both downloads should succeed")
+        }
       }
     }
   }
@@ -151,7 +155,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     ) { downloader =>
       val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-      result shouldBe a[Success[_]]
+      result shouldBe a[Right[_, _]]
       val file = dir.resolve(s"$subject-1.avsc")
       Files.exists(file) shouldBe true
       readFile(file) shouldBe schemaJson
@@ -173,13 +177,13 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
 
     withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
       val latestResult = downloader.schemaSubjectToFile(RegistrySubject.latest(subject))
-      latestResult shouldBe a[Success[_]]
+      latestResult shouldBe a[Right[_, _]]
       val latestFile = dir.resolve(s"$subject-3.avsc")
       Files.exists(latestFile) shouldBe true
       readFile(latestFile) shouldBe v3Json
 
       val pinnedResult = downloader.schemaSubjectToFile(RegistrySubject(subject, 2))
-      pinnedResult shouldBe a[Success[_]]
+      pinnedResult shouldBe a[Right[_, _]]
       val pinnedFile = dir.resolve(s"$subject-2.avsc")
       Files.exists(pinnedFile) shouldBe true
       readFile(pinnedFile) shouldBe v2Json
@@ -193,7 +197,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     Files.createDirectories(dir2)
     withDownloader(Downloader(registryUrl, dir2, silentLogger)) { downloader2 =>
       val latestV4Result = downloader2.schemaSubjectToFile(RegistrySubject.latest(subject))
-      latestV4Result shouldBe a[Success[_]]
+      latestV4Result shouldBe a[Right[_, _]]
       val latestV4File = dir2.resolve(s"$subject-4.avsc")
       Files.exists(latestV4File) shouldBe true
       readFile(latestV4File) shouldBe v4Json
@@ -216,7 +220,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
       val result = downloader.schemaSubjectToFile(RegistrySubject.latest(mainSubject))
 
-      result shouldBe a[Success[_]]
+      result shouldBe a[Right[_, _]]
       val file = dir.resolve(s"$mainSubject-1.avsc")
       Files.exists(file) shouldBe true
       readFile(file) shouldBe mainJson
@@ -235,7 +239,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     withDownloader(Downloader(registryUrl, deepDir, silentLogger)) { downloader =>
       val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
 
-      result shouldBe a[Success[_]]
+      result shouldBe a[Right[_, _]]
       Files.exists(deepDir) shouldBe true
       val file = deepDir.resolve(s"$subject-1.avsc")
       Files.exists(file) shouldBe true
@@ -251,14 +255,14 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
 
     withDownloader(Downloader(registryUrl, dir, silentLogger)) { downloader =>
       val first = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
-      first shouldBe a[Success[_]]
+      first shouldBe a[Right[_, _]]
 
       val file = dir.resolve(s"$subject-1.avsc")
       Files.write(file, "corrupted".getBytes())
       readFile(file) shouldBe "corrupted"
 
       val second = downloader.schemaSubjectToFile(RegistrySubject(subject, 1))
-      second shouldBe a[Success[_]]
+      second shouldBe a[Right[_, _]]
       readFile(file) shouldBe schemaJson
     }
   }

--- a/src/main/scala/org/galaxio/avro/DownloadError.scala
+++ b/src/main/scala/org/galaxio/avro/DownloadError.scala
@@ -1,0 +1,25 @@
+package org.galaxio.avro
+
+import java.nio.file.Path
+
+sealed trait DownloadError {
+  def message: String
+  def cause: Option[Throwable] = None
+}
+
+object DownloadError {
+
+  final case class InvalidSubjectName(name: String) extends DownloadError {
+    val message: String = s"Subject name must not contain path separators: $name"
+  }
+
+  final case class SchemaFetchFailed(subject: String, error: Throwable) extends DownloadError {
+    val message: String                   = s"Failed to fetch schema $subject: ${error.getMessage}"
+    override val cause: Option[Throwable] = Some(error)
+  }
+
+  final case class WriteError(path: Path, error: Throwable) extends DownloadError {
+    val message: String                   = s"Failed to write schema to $path: ${error.getMessage}"
+    override val cause: Option[Throwable] = Some(error)
+  }
+}

--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -1,52 +1,62 @@
 package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaRegistryClient}
+import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import java.util.{Collections, HashMap => JHashMap}
 import scala.util.Try
-import sbt.util.Logger
 
-class Downloader private (client: SchemaRegistryClient, schemaOutputDir: Path, logger: Logger, closeAction: () => Unit)
-    extends AutoCloseable {
-
-  def this(client: SchemaRegistryClient, schemaOutputDir: Path, logger: Logger) =
-    this(client, schemaOutputDir, logger, () => ())
+final class Downloader private[avro] (
+    client: SchemaRegistryClient,
+    schemaOutputDir: Path,
+    logger: Logger,
+    closeAction: () => Unit = () => (),
+) extends AutoCloseable {
 
   override def close(): Unit =
     Try(closeAction()).failed.foreach(e => logger.warn(s"Failed to close schema registry client: ${e.getMessage}"))
 
-  private def createOutputDirIfNeeded(): Unit =
-    if (Files.notExists(schemaOutputDir))
-      Files.createDirectories(schemaOutputDir)
+  def schemaSubjectToFile(subject: RegistrySubject): Either[DownloadError, Path] =
+    for {
+      _        <- validateSubjectName(subject.name)
+      resolved <- fetchSchema(subject)
+      path     <- writeSchema(subject.name, resolved)
+    } yield path
 
-  private def fileName(subject: String, version: Int): String =
-    s"$subject-$version.${Downloader.avroSchemaFileExtension}"
+  private def validateSubjectName(name: String): Either[DownloadError, Unit] =
+    if (name.contains('/') || name.contains('\\')) Left(DownloadError.InvalidSubjectName(name))
+    else Right(())
 
-  private def validateSubjectName(name: String): Unit =
-    require(!name.contains('/') && !name.contains('\\'), s"Subject name must not contain path separators: $name")
-
-  def schemaSubjectToFile(subject: RegistrySubject): Try[Path] = Try {
-    validateSubjectName(subject.name)
-    val versionLabel = subject.version.map(_.toString).getOrElse("latest")
-    logger.info(s"Downloading schema ${subject.name} version=$versionLabel")
-
-    val (version: Int, schemaText: String) = subject.version match {
-      case Some(v) =>
-        val s = client.getByVersion(subject.name, v, false)
-        (s.getVersion: Int, s.getSchema)
-      case None    =>
-        val meta = client.getLatestSchemaMetadata(subject.name)
-        (meta.getVersion: Int, meta.getSchema)
-    }
-
-    createOutputDirIfNeeded()
-    val name = fileName(subject.name, version)
-    val path = Files.write(schemaOutputDir.resolve(name), schemaText.getBytes())
-    logger.info(s"Saved schema ${subject.name} to $path")
-    path
+  private def fetchSchema(subject: RegistrySubject): Either[DownloadError, (Int, String)] = {
+    logger.info(s"Downloading schema ${subject.name} version=${versionLabel(subject)}")
+    Try {
+      subject match {
+        case RegistrySubject.Pinned(name, version) =>
+          val s = client.getByVersion(name, version, false)
+          (s.getVersion: Int, s.getSchema)
+        case RegistrySubject.Latest(name)          =>
+          val meta = client.getLatestSchemaMetadata(name)
+          (meta.getVersion: Int, meta.getSchema)
+      }
+    }.toEither.left.map(DownloadError.SchemaFetchFailed(subject.name, _))
   }
 
+  private def writeSchema(subjectName: String, resolved: (Int, String)): Either[DownloadError, Path] = {
+    val (version, body) = resolved
+    Try {
+      if (Files.notExists(schemaOutputDir)) Files.createDirectories(schemaOutputDir)
+      val fileName = s"$subjectName-$version.${Downloader.avroSchemaFileExtension}"
+      val path     = Files.write(schemaOutputDir.resolve(fileName), body.getBytes())
+      logger.info(s"Saved schema $subjectName to $path")
+      path
+    }.toEither.left.map(DownloadError.WriteError(schemaOutputDir, _))
+  }
+
+  private def versionLabel(subject: RegistrySubject): String = subject match {
+    case RegistrySubject.Pinned(_, v) => v.toString
+    case _: RegistrySubject.Latest    => "latest"
+  }
 }
 
 object Downloader {
@@ -56,14 +66,14 @@ object Downloader {
   private[avro] def buildConfig(
       auth: Option[SchemaRegistryAuth],
       properties: Map[String, String],
-  ): JHashMap[String, Any] = {
-    val config = new JHashMap[String, Any]()
-    properties.foreach { case (k, v) => config.put(k, v) }
-    auth.foreach { case SchemaRegistryAuth.BasicAuth(user, pass) =>
-      config.put("basic.auth.credentials.source", "USER_INFO")
-      config.put("basic.auth.user.info", s"$user:$pass")
+  ): Map[String, Any] = {
+    val authEntries = auth.fold(Map.empty[String, Any]) { case SchemaRegistryAuth.BasicAuth(user, pass) =>
+      Map[String, Any](
+        "basic.auth.credentials.source" -> "USER_INFO",
+        "basic.auth.user.info"          -> s"$user:$pass",
+      )
     }
-    config
+    properties ++ authEntries
   }
 
   def apply(
@@ -74,11 +84,16 @@ object Downloader {
       auth: Option[SchemaRegistryAuth] = None,
       properties: Map[String, String] = Map.empty,
   ): Downloader = {
-    val config = buildConfig(auth, properties)
+    val config     = buildConfig(auth, properties)
+    val javaConfig = {
+      val m = new JHashMap[String, Any]()
+      config.foreach { case (k, v) => m.put(k, v) }
+      m
+    }
 
     val client =
-      if (config.isEmpty) new CachedSchemaRegistryClient(rootUrl, cacheSize)
-      else new CachedSchemaRegistryClient(Collections.singletonList(rootUrl), cacheSize, config)
+      if (javaConfig.isEmpty) new CachedSchemaRegistryClient(rootUrl, cacheSize)
+      else new CachedSchemaRegistryClient(Collections.singletonList(rootUrl), cacheSize, javaConfig)
 
     new Downloader(client, schemaOutputDir, logger, () => client.close())
   }

--- a/src/main/scala/org/galaxio/avro/RegistrySubject.scala
+++ b/src/main/scala/org/galaxio/avro/RegistrySubject.scala
@@ -1,8 +1,15 @@
 package org.galaxio.avro
 
-final case class RegistrySubject(name: String, version: Option[Int] = None)
+sealed trait RegistrySubject {
+  def name: String
+}
 
 object RegistrySubject {
-  def apply(name: String, version: Int): RegistrySubject = RegistrySubject(name, Some(version))
-  def latest(name: String): RegistrySubject              = RegistrySubject(name, None)
+  final case class Pinned(name: String, version: Int) extends RegistrySubject
+  final case class Latest(name: String)               extends RegistrySubject
+
+  def apply(name: String, version: Int): RegistrySubject                = Pinned(name, version)
+  def apply(name: String, version: Option[Int] = None): RegistrySubject =
+    version.fold(latest(name))(Pinned(name, _))
+  def latest(name: String): RegistrySubject                             = Latest(name)
 }

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -53,12 +53,12 @@ object SchemaDownloaderPlugin extends AutoPlugin {
           ),
         ) { downloader =>
           val results  = subjects.map(s => s -> downloader.schemaSubjectToFile(s))
-          val failures = results.collect { case (s, scala.util.Failure(e)) => s -> e }
+          val failures = results.collect { case (s, Left(e)) => s -> e }
 
           if (failures.nonEmpty) {
             failures.foreach { case (s, e) =>
-              logger.error(s"Failed to download schema ${s.name}: ${e.getMessage}")
-              logger.trace(e)
+              logger.error(s"Failed to download schema ${s.name}: ${e.message}")
+              e.cause.foreach(logger.trace(_))
             }
             sys.error(s"Failed to download ${failures.size} schema(s)")
           }

--- a/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
@@ -12,27 +12,22 @@ import sbt.util.Logger
 import java.io.IOException
 import java.nio.file.{Files, Path}
 import java.util.Collections
-import scala.util.{Failure, Success}
 
 class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
-  private def testLogger: Logger = {
-    val log = mock[Logger]
-    log
-  }
+  private def testLogger: Logger = mock[Logger]
+
+  private def readFile(path: Path): String =
+    new String(Files.readAllBytes(path))
 
   private def withTempDir(test: Path => Any): Unit = {
     val dir = Files.createTempDirectory("downloader-test")
     try test(dir)
-    finally {
-      Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists)
-    }
+    finally Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists)
   }
 
-  private def schemaEntity(subject: String, version: Int, schemaStr: String): Schema = {
-    val s = new Schema(subject, version, 1, "AVRO", Collections.emptyList(), schemaStr)
-    s
-  }
+  private def schemaEntity(subject: String, version: Int, schemaStr: String): Schema =
+    new Schema(subject, version, 1, "AVRO", Collections.emptyList(), schemaStr)
 
   "Downloader" should "download schema with specific version" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
@@ -42,10 +37,10 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject("test-subject", 2))
 
-    result shouldBe a[Success[_]]
+    result shouldBe a[Right[_, _]]
     val file = dir.resolve("test-subject-2.avsc")
     Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe """{"type":"record","name":"Test","fields":[]}"""
+    readFile(file) shouldBe """{"type":"record","name":"Test","fields":[]}"""
   }
 
   it should "download latest version when version is None" in withTempDir { dir =>
@@ -56,10 +51,10 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject.latest("test-subject"))
 
-    result shouldBe a[Success[_]]
+    result shouldBe a[Right[_, _]]
     val file = dir.resolve("test-subject-5.avsc")
     Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe """{"type":"string"}"""
+    readFile(file) shouldBe """{"type":"string"}"""
   }
 
   it should "create output directory if it does not exist" in withTempDir { dir =>
@@ -71,12 +66,12 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val downloader = new Downloader(client, outputDir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject("test", 1))
 
-    result shouldBe a[Success[_]]
+    result shouldBe a[Right[_, _]]
     Files.exists(outputDir) shouldBe true
     Files.exists(outputDir.resolve("test-1.avsc")) shouldBe true
   }
 
-  it should "return Failure on network error" in withTempDir { dir =>
+  it should "return Left with SchemaFetchFailed on network error" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     when(client.getByVersion(anyString(), anyInt(), anyBoolean()))
       .thenThrow(new IOException("Connection refused"))
@@ -84,11 +79,12 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject("fail-subject", 1))
 
-    result shouldBe a[Failure[_]]
-    result.failed.get.getMessage shouldBe "Connection refused"
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
+    result.left.get.message should include("Connection refused")
   }
 
-  it should "return Failure when schema not found" in withTempDir { dir =>
+  it should "return Left with SchemaFetchFailed when schema not found" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     when(client.getByVersion(anyString(), anyInt(), anyBoolean()))
       .thenThrow(new RuntimeException("Subject not found"))
@@ -96,7 +92,8 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject("missing", 1))
 
-    result shouldBe a[Failure[_]]
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
   }
 
   it should "use correct file extension" in withTempDir { dir =>
@@ -116,8 +113,8 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
       Map.empty,
     )
 
-    config.get("basic.auth.credentials.source") shouldBe "USER_INFO"
-    config.get("basic.auth.user.info") shouldBe "alice:s3cret"
+    config("basic.auth.credentials.source") shouldBe "USER_INFO"
+    config("basic.auth.user.info") shouldBe "alice:s3cret"
   }
 
   it should "pass through arbitrary properties unchanged" in {
@@ -129,9 +126,9 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
       ),
     )
 
-    config.get("schema.registry.ssl.truststore.location") shouldBe "/etc/pki/trust.jks"
-    config.get("schema.registry.ssl.truststore.password") shouldBe "changeit"
-    config.size() shouldBe 2
+    config("schema.registry.ssl.truststore.location") shouldBe "/etc/pki/trust.jks"
+    config("schema.registry.ssl.truststore.password") shouldBe "changeit"
+    config.size shouldBe 2
   }
 
   it should "merge auth and properties without key loss" in {
@@ -140,10 +137,10 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
       Map("custom.prop" -> "val"),
     )
 
-    config.get("basic.auth.credentials.source") shouldBe "USER_INFO"
-    config.get("basic.auth.user.info") shouldBe "bob:pw"
-    config.get("custom.prop") shouldBe "val"
-    config.size() shouldBe 3
+    config("basic.auth.credentials.source") shouldBe "USER_INFO"
+    config("basic.auth.user.info") shouldBe "bob:pw"
+    config("custom.prop") shouldBe "val"
+    config.size shouldBe 3
   }
 
   it should "return empty map when no auth and no properties" in {
@@ -151,22 +148,39 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     config shouldBe empty
   }
 
-  "Downloader" should "reject subject name with forward slash" in withTempDir { dir =>
+  "Downloader" should "return Left with InvalidSubjectName for forward slash" in withTempDir { dir =>
     val client     = mock[SchemaRegistryClient]
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject("a/b", 1))
 
-    result shouldBe a[Failure[_]]
-    result.failed.get.getMessage should include("path separators")
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.InvalidSubjectName]
+    result.left.get.message should include("path separators")
   }
 
-  it should "reject subject name with backslash" in withTempDir { dir =>
+  it should "return Left with InvalidSubjectName for backslash" in withTempDir { dir =>
     val client     = mock[SchemaRegistryClient]
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject("a\\b", 1))
 
-    result shouldBe a[Failure[_]]
-    result.failed.get.getMessage should include("path separators")
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.InvalidSubjectName]
+    result.left.get.message should include("path separators")
+  }
+
+  it should "return Left with WriteError when output path is not writable" in withTempDir { dir =>
+    val blocker = dir.resolve("blocker")
+    Files.createFile(blocker)
+
+    val client = mock[SchemaRegistryClient]
+    val schema = schemaEntity("test", 1, """{"type":"null"}""")
+    when(client.getByVersion("test", 1, false)).thenReturn(schema)
+
+    val downloader = new Downloader(client, blocker.resolve("sub"), testLogger)
+    val result     = downloader.schemaSubjectToFile(RegistrySubject("test", 1))
+
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.WriteError]
   }
 
   it should "be safe to call close multiple times" in withTempDir { dir =>
@@ -187,7 +201,7 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject.latest("my-subject"))
 
-    result shouldBe a[Success[_]]
+    result shouldBe a[Right[_, _]]
     val file = dir.resolve("my-subject-7.avsc")
     Files.exists(file) shouldBe true
     Files.exists(dir.resolve("my-subject-latest.avsc")) shouldBe false
@@ -201,10 +215,9 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val downloader = new Downloader(client, dir, testLogger)
     val result     = downloader.schemaSubjectToFile(RegistrySubject("empty-schema", 1))
 
-    result shouldBe a[Success[_]]
+    result shouldBe a[Right[_, _]]
     val file = dir.resolve("empty-schema-1.avsc")
     Files.exists(file) shouldBe true
-    new String(Files.readAllBytes(file)) shouldBe ""
+    readFile(file) shouldBe ""
   }
-
 }

--- a/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
@@ -169,7 +169,7 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     result.failed.get.getMessage should include("path separators")
   }
 
-  it should "close should be safe to call multiple times" in withTempDir { dir =>
+  it should "be safe to call close multiple times" in withTempDir { dir =>
     val client     = mock[SchemaRegistryClient]
     val downloader = new Downloader(client, dir, testLogger)
 
@@ -179,7 +179,7 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     }
   }
 
-  it should "latest download should use resolved version number in filename" in withTempDir { dir =>
+  it should "use resolved version number in filename for latest" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     val meta   = new SchemaMetadata(1, 7, "AVRO", Collections.emptyList(), """{"type":"int"}""")
     when(client.getLatestSchemaMetadata("my-subject")).thenReturn(meta)
@@ -193,7 +193,7 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     Files.exists(dir.resolve("my-subject-latest.avsc")) shouldBe false
   }
 
-  it should "empty schema body should write zero-byte file" in withTempDir { dir =>
+  it should "write zero-byte file for empty schema body" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     val schema = schemaEntity("empty-schema", 1, "")
     when(client.getByVersion("empty-schema", 1, false)).thenReturn(schema)

--- a/src/test/scala/org/galaxio/avro/RegistrySubjectSpec.scala
+++ b/src/test/scala/org/galaxio/avro/RegistrySubjectSpec.scala
@@ -5,21 +5,30 @@ import org.scalatest.matchers.should.Matchers
 
 class RegistrySubjectSpec extends AnyFlatSpec with Matchers {
 
-  "RegistrySubject" should "create with specific version" in {
+  "RegistrySubject" should "create Pinned with specific version" in {
     val subject = RegistrySubject("test-schema", 3)
+    subject shouldBe RegistrySubject.Pinned("test-schema", 3)
     subject.name shouldBe "test-schema"
-    subject.version shouldBe Some(3)
   }
 
-  it should "create latest version via factory method" in {
+  it should "create Latest via factory method" in {
     val subject = RegistrySubject.latest("test-schema")
+    subject shouldBe RegistrySubject.Latest("test-schema")
     subject.name shouldBe "test-schema"
-    subject.version shouldBe None
   }
 
-  it should "default version to None" in {
+  it should "default to Latest when no version given" in {
     val subject = RegistrySubject("test-schema")
-    subject.version shouldBe None
+    subject shouldBe RegistrySubject.Latest("test-schema")
   }
 
+  it should "create Pinned from Option[Int] with Some" in {
+    val subject = RegistrySubject("test-schema", Some(5))
+    subject shouldBe RegistrySubject.Pinned("test-schema", 5)
+  }
+
+  it should "create Latest from Option[Int] with None" in {
+    val subject = RegistrySubject("test-schema", None)
+    subject shouldBe RegistrySubject.Latest("test-schema")
+  }
 }


### PR DESCRIPTION
## Summary

- **Idiomatic FP rewrite**: `Try[Path]` → `Either[DownloadError, Path]` with sealed `DownloadError` ADT (`InvalidSubjectName`, `SchemaFetchFailed`, `WriteError`)
- **`RegistrySubject` ADT**: `case class` with `Option[Int]` → sealed trait with `Pinned`/`Latest` variants; backward-compatible factory methods preserved
- **Pure validation**: `require`/`throw` → `Either` with for-comprehension pipeline
- **Immutable config**: `buildConfig` returns `Map[String, Any]` instead of mutable `JHashMap`
- **Test coverage**: 21 unit tests (+9), 10 integration tests (+5), all with typed error assertions and proper `Downloader` resource cleanup

### Breaking changes

- `Downloader.schemaSubjectToFile` returns `Either[DownloadError, Path]` instead of `Try[Path]`
- `RegistrySubject` is now a sealed trait (was case class) — construction via `apply`/`latest` unchanged
- `Downloader.buildConfig` returns `Map[String, Any]` instead of `JHashMap[String, Any]`

## Test plan

- [x] `sbt test` — 21 unit tests pass
- [x] `sbt it/Test/compile` — integration tests compile
- [ ] `sbt it/test` — integration tests (requires Docker, CI)
- [ ] `sbt scripted` — E2E plugin tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)