### PR TITLE
chore(deps): bump mockito-scala-scalatest 2.0.0 → 2.2.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   private object Versions {
     val schReqClient   = "8.2.1"
     val scalatest      = "3.2.19"
-    val mockito        = "2.0.0"
+    val mockito        = "2.2.1"
     val testcontainers = "1.21.3"
   }
 


### PR DESCRIPTION
## Summary
- Bump `mockito-scala-scalatest` from 2.0.0 to 2.2.1
- Replaces orphan Scala Steward branch `update/mockito-scala-scalatest-2.2.1` (deleted, had no PR)

## Test plan
- [x] 21 unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)