### PR TITLE
chore(deps): bump sbt 1.12.12, testcontainers 1.21.4, mockito-scala 2.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.*
 
-val sbtV = "1.12.11"
+val sbtV = "1.12.12"
 
 lazy val commonSettings = Seq(
   scalaVersion := "2.12.21",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
     val schReqClient   = "8.2.1"
     val scalatest      = "3.2.19"
     val mockito        = "2.2.1"
-    val testcontainers = "1.21.3"
+    val testcontainers = "1.21.4"
   }
 
   lazy val schemaRegistryClient: ModuleID = "io.confluent" % "kafka-schema-registry-client" % Versions.schReqClient

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty"
-sbt.version=1.12.11
+sbt.version=1.12.12


### PR DESCRIPTION
## Summary
- sbt 1.12.11 → 1.12.12
- testcontainers 1.21.3 → 1.21.4
- mockito-scala-scalatest 2.0.0 → 2.2.1 (supersedes #36)

All other deps already at latest: schema-registry-client 8.2.1, scalatest 3.2.19, sbt-ci-release 1.11.2, sbt-scalafmt 2.6.1. GH Actions pinned to major versions — auto-resolve to latest.

## Test plan
- [x] 21 unit tests pass locally
- [ ] CI green (format, test, it/test, scripted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)