### PR TITLE
chore: ignore scala-library and sbt in Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,6 @@
+updates.ignore = [
+  # sbt 1.x plugins must compile under Scala 2.12
+  { groupId = "org.scala-lang", artifactId = "scala-library" }
+  # sbt 2.x requires Scala 3 migration — not a drop-in upgrade
+  { groupId = "org.scala-sbt", artifactId = "sbt" }
+]


### PR DESCRIPTION
## Summary
- Add `.scala-steward.conf` ignoring `scala-library` and `sbt` upgrades
- sbt 1.x plugins must compile under Scala 2.12 — bumping to 2.13 breaks all users
- sbt 2.0 requires Scala 3 migration — not a drop-in upgrade
- Prevents Scala Steward from creating breaking PRs like #39 and #40

## Test plan
- [ ] Next Scala Steward run skips scala-library and sbt

🤖 Generated with [Claude Code](https://claude.com/claude-code)