### PR TITLE
feat: add schema compatibility check before deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,32 @@ RegistryRegistration("user-value", file("src/main/avro/User.json"), SchemaType.J
 | `schemaRegistryRegistrations` | List of subject-to-file schema mappings | `Seq()`    |
 
 All connection settings (`schemaRegistryUrl`, `schemaRegistryAuth`, `schemaRegistryProperties`) are
-shared between download and registration tasks.
+shared between download, registration, and compatibility tasks.
+
+## Schema Compatibility Check
+
+Verify that local schemas are compatible with versions already registered in Schema Registry
+before deploying:
+
+```bash
+sbt "Compile / schemaRegistryTestCompatibility"
+```
+
+The task uses the same `schemaRegistryRegistrations` setting as `schemaRegistryRegister`. For each
+subject it calls `testCompatibilityVerbose` against the registry and reports:
+
+- **Compatible** — the new schema can safely be registered
+- **Incompatible** — the registry would reject registration; verbose messages explain why
+- **Failed** — an error occurred (file not found, parse error, network issue)
+
+The build fails if any subject is incompatible or fails. Use this in CI before registration to
+catch breaking changes early:
+
+```sbt
+Compile / compile := (Compile / compile)
+  .dependsOn(Compile / schemaRegistryTestCompatibility)
+  .value
+```
 
 ## Workflow Integration
 

--- a/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
@@ -1,0 +1,132 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+import java.io.File
+import java.nio.file.Files
+import scala.util.Try
+
+class CompatibilityCheckerIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private var network: Network                           = _
+  private var kafka: ConfluentKafkaContainer             = _
+  private var sr: JGenericContainer[_]                   = _
+  private var registryUrl: String                        = _
+  private var registryClient: CachedSchemaRegistryClient = _
+
+  override def beforeAll(): Unit = {
+    network = Network.newNetwork()
+
+    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+    kafka.withListener("kafka:19092")
+    kafka.withNetwork(network)
+    kafka.start()
+
+    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
+    sr.withNetwork(network)
+    sr.withExposedPorts(8081)
+    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+    sr.start()
+
+    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
+    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
+  }
+
+  override def afterAll(): Unit = {
+    Option(registryClient).foreach(c => Try(c.close()))
+    Option(sr).foreach(c => Try(c.stop()))
+    Option(kafka).foreach(c => Try(c.stop()))
+    Option(network).foreach(c => Try(c.close()))
+  }
+
+  private def tempSchemaFile(content: String): File = {
+    val f = File.createTempFile("compat-it-", ".avsc")
+    f.deleteOnExit()
+    Files.write(f.toPath, content.getBytes("UTF-8"))
+    f
+  }
+
+  "CompatibilityChecker (integration)" should "return Compatible for a backward-compatible change" in {
+    val v1 =
+      """{"type":"record","name":"CompatV1","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
+    val v2 =
+      """{"type":"record","name":"CompatV1","namespace":"org.galaxio","fields":[{"name":"id","type":"long"},{"name":"name","type":"string","default":""}]}"""
+
+    registryClient.register("compat-check-pass", new AvroSchema(v1))
+
+    val file   = tempSchemaFile(v2)
+    val result = CompatibilityChecker.checkOne(registryClient, RegistryRegistration("compat-check-pass", file))
+    result shouldBe CompatibilityResult.Compatible("compat-check-pass")
+  }
+
+  it should "return Incompatible with verbose messages for a breaking change" in {
+    val v1 =
+      """{"type":"record","name":"CompatV2","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
+    val v2breaking =
+      """{"type":"record","name":"CompatV2","namespace":"org.galaxio","fields":[{"name":"id","type":"long"},{"name":"name","type":"string"}]}"""
+
+    registryClient.register("compat-check-fail", new AvroSchema(v1))
+
+    val file   = tempSchemaFile(v2breaking)
+    val result = CompatibilityChecker.checkOne(registryClient, RegistryRegistration("compat-check-fail", file))
+    result shouldBe a[CompatibilityResult.Incompatible]
+    val incompatible = result.asInstanceOf[CompatibilityResult.Incompatible]
+    incompatible.messages should not be empty
+  }
+
+  it should "return Compatible for a brand-new subject with no prior versions" in {
+    val schema =
+      """{"type":"record","name":"BrandNew","namespace":"org.galaxio","fields":[{"name":"x","type":"int"}]}"""
+    val file   = tempSchemaFile(schema)
+    val result = CompatibilityChecker.checkOne(registryClient, RegistryRegistration("compat-new-subject", file))
+    result shouldBe CompatibilityResult.Compatible("compat-new-subject")
+  }
+
+  it should "return Failed for invalid schema content" in {
+    val file   = tempSchemaFile("not valid json at all")
+    val result = CompatibilityChecker.checkOne(registryClient, RegistryRegistration("compat-invalid", file))
+    result shouldBe a[CompatibilityResult.Failed]
+  }
+
+  it should "return Failed for missing file" in {
+    val result = CompatibilityChecker.checkOne(
+      registryClient,
+      RegistryRegistration("compat-missing", new File("/nonexistent.avsc")),
+    )
+    result shouldBe a[CompatibilityResult.Failed]
+    result.asInstanceOf[CompatibilityResult.Failed].cause shouldBe a[RegistryError.FileNotFound]
+  }
+
+  it should "check all subjects independently in a batch" in {
+    val v1 =
+      """{"type":"record","name":"BatchTest","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
+    registryClient.register("compat-batch", new AvroSchema(v1))
+
+    val compatible =
+      """{"type":"record","name":"BatchTest","namespace":"org.galaxio","fields":[{"name":"id","type":"long"},{"name":"extra","type":"string","default":""}]}"""
+    val incompatible =
+      """{"type":"record","name":"BatchTest","namespace":"org.galaxio","fields":[{"name":"id","type":"long"},{"name":"required_field","type":"string"}]}"""
+
+    val report = CompatibilityChecker.checkAll(
+      registryClient,
+      List(
+        RegistryRegistration("compat-batch", tempSchemaFile(compatible)),
+        RegistryRegistration("compat-batch", tempSchemaFile(incompatible)),
+      ),
+    )
+
+    report.compatible should have size 1
+    report.incompatible should have size 1
+    report.isSuccess shouldBe false
+  }
+}

--- a/src/main/scala/org/galaxio/avro/CompatibilityChecker.scala
+++ b/src/main/scala/org/galaxio/avro/CompatibilityChecker.scala
@@ -15,7 +15,7 @@ object CompatibilityChecker {
       content  <- Registrar.readSchemaFile(reg)
       parsed   <- Registrar.buildParsedSchema(reg.subject, content, reg.schemaType)
       messages <- Try(client.testCompatibilityVerbose(reg.subject, parsed).asScala.toList).toEither.left
-                    .map(RegistryError.RegistrationFailed(reg.subject, _))
+                    .map(RegistryError.CompatibilityCheckFailed(reg.subject, _))
     } yield messages
 
     result match {

--- a/src/main/scala/org/galaxio/avro/CompatibilityChecker.scala
+++ b/src/main/scala/org/galaxio/avro/CompatibilityChecker.scala
@@ -1,0 +1,33 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+object CompatibilityChecker {
+
+  def checkOne(
+      client: SchemaRegistryClient,
+      reg: RegistryRegistration,
+  ): CompatibilityResult = {
+    val result = for {
+      content  <- Registrar.readSchemaFile(reg)
+      parsed   <- Registrar.buildParsedSchema(reg.subject, content, reg.schemaType)
+      messages <- Try(client.testCompatibilityVerbose(reg.subject, parsed).asScala.toList).toEither.left
+                    .map(RegistryError.RegistrationFailed(reg.subject, _))
+    } yield messages
+
+    result match {
+      case Right(Nil)      => CompatibilityResult.Compatible(reg.subject)
+      case Right(messages) => CompatibilityResult.Incompatible(reg.subject, messages)
+      case Left(err)       => CompatibilityResult.Failed(reg.subject, err)
+    }
+  }
+
+  def checkAll(
+      client: SchemaRegistryClient,
+      registrations: List[RegistryRegistration],
+  ): CompatibilityReport =
+    CompatibilityReport(registrations.map(checkOne(client, _)))
+}

--- a/src/main/scala/org/galaxio/avro/CompatibilityReport.scala
+++ b/src/main/scala/org/galaxio/avro/CompatibilityReport.scala
@@ -1,0 +1,15 @@
+package org.galaxio.avro
+
+final case class CompatibilityReport(results: List[CompatibilityResult]) {
+
+  lazy val compatible: List[CompatibilityResult.Compatible] =
+    results.collect { case c: CompatibilityResult.Compatible => c }
+
+  lazy val incompatible: List[CompatibilityResult.Incompatible] =
+    results.collect { case i: CompatibilityResult.Incompatible => i }
+
+  lazy val failed: List[CompatibilityResult.Failed] =
+    results.collect { case f: CompatibilityResult.Failed => f }
+
+  def isSuccess: Boolean = incompatible.isEmpty && failed.isEmpty
+}

--- a/src/main/scala/org/galaxio/avro/CompatibilityResult.scala
+++ b/src/main/scala/org/galaxio/avro/CompatibilityResult.scala
@@ -1,0 +1,11 @@
+package org.galaxio.avro
+
+sealed trait CompatibilityResult extends Product with Serializable {
+  def subject: String
+}
+
+object CompatibilityResult {
+  final case class Compatible(subject: String)                           extends CompatibilityResult
+  final case class Incompatible(subject: String, messages: List[String]) extends CompatibilityResult
+  final case class Failed(subject: String, cause: RegistryError)         extends CompatibilityResult
+}

--- a/src/main/scala/org/galaxio/avro/RegistryError.scala
+++ b/src/main/scala/org/galaxio/avro/RegistryError.scala
@@ -23,6 +23,11 @@ object RegistryError {
     override val cause: Option[Throwable] = Some(error)
   }
 
+  final case class CompatibilityCheckFailed(subject: String, error: Throwable) extends RegistryError {
+    val message: String                   = s"Compatibility check failed for $subject: ${error.getMessage}"
+    override val cause: Option[Throwable] = Some(error)
+  }
+
   final case class UnsupportedSchemaType(ext: String) extends RegistryError {
     val message: String = s"Unsupported schema file extension: $ext"
   }

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -1,5 +1,6 @@
 package org.galaxio.avro
 
+import _root_.io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import sbt.*
 import Keys.*
 
@@ -32,6 +33,14 @@ object SchemaDownloaderPlugin extends AutoPlugin {
   }
 
   import autoImport.*
+
+  private def withRegistryClient[A](
+      url: String,
+      cacheSize: Int,
+      auth: Option[SchemaRegistryAuth],
+      properties: Map[String, String],
+  )(f: SchemaRegistryClient => A): A =
+    Using.resource(Downloader.buildClient(url, cacheSize, auth, properties))(f)
 
   override lazy val projectSettings: Seq[Setting[?]] = defaultSettings ++ Seq(
     schemaRegistryDownload                    := (Compile / schemaRegistryDownload).value,
@@ -77,13 +86,12 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       if (registrations.isEmpty) {
         logger.warn("No schema registrations configured. Set schemaRegistryRegistrations to register schemas.")
       } else {
-        val client = Downloader.buildClient(
-          rootUrl = schemaRegistryUrl.value,
-          cacheSize = schemaRegistryCacheSize.value,
-          auth = schemaRegistryAuth.value,
-          properties = schemaRegistryProperties.value,
-        )
-        Using.resource(client) { c =>
+        withRegistryClient(
+          schemaRegistryUrl.value,
+          schemaRegistryCacheSize.value,
+          schemaRegistryAuth.value,
+          schemaRegistryProperties.value,
+        ) { c =>
           val results             = Registrar.registerAll(c, registrations)
           val (errors, successes) = Registrar.partitionResults(results)
 
@@ -105,13 +113,12 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       if (registrations.isEmpty) {
         logger.warn("No schema registrations configured. Set schemaRegistryRegistrations to check compatibility.")
       } else {
-        val client = Downloader.buildClient(
-          rootUrl = schemaRegistryUrl.value,
-          cacheSize = schemaRegistryCacheSize.value,
-          auth = schemaRegistryAuth.value,
-          properties = schemaRegistryProperties.value,
-        )
-        Using.resource(client) { c =>
+        withRegistryClient(
+          schemaRegistryUrl.value,
+          schemaRegistryCacheSize.value,
+          schemaRegistryAuth.value,
+          schemaRegistryProperties.value,
+        ) { c =>
           val report = CompatibilityChecker.checkAll(c, registrations)
 
           report.compatible.foreach(r => logger.info(s"✓ ${r.subject} is compatible"))

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -9,15 +9,16 @@ object SchemaDownloaderPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
-    val schemaRegistryDownload      = taskKey[Unit]("Download schemas from schema registry")
-    val schemaRegistryRegister      = taskKey[Unit]("Register (push) schemas to schema registry")
-    val schemaRegistryUrl           = settingKey[String]("URL of the schema registry")
-    val schemaRegistryTargetFolder  = settingKey[File]("Output directory for downloaded schemas")
-    val schemaRegistrySubjects      = settingKey[Seq[RegistrySubject]]("Schema subjects to download")
-    val schemaRegistryRegistrations = settingKey[Seq[RegistryRegistration]]("Schema registrations to push")
-    val schemaRegistryCacheSize     = settingKey[Int]("Schema registry client cache size")
-    val schemaRegistryAuth          = settingKey[Option[SchemaRegistryAuth]]("Schema registry authentication")
-    val schemaRegistryProperties    = settingKey[Map[String, String]]("Additional schema registry client properties")
+    val schemaRegistryDownload          = taskKey[Unit]("Download schemas from schema registry")
+    val schemaRegistryRegister          = taskKey[Unit]("Register (push) schemas to schema registry")
+    val schemaRegistryTestCompatibility = taskKey[Unit]("Check schema compatibility against registry")
+    val schemaRegistryUrl               = settingKey[String]("URL of the schema registry")
+    val schemaRegistryTargetFolder      = settingKey[File]("Output directory for downloaded schemas")
+    val schemaRegistrySubjects          = settingKey[Seq[RegistrySubject]]("Schema subjects to download")
+    val schemaRegistryRegistrations     = settingKey[Seq[RegistryRegistration]]("Schema registrations to push")
+    val schemaRegistryCacheSize         = settingKey[Int]("Schema registry client cache size")
+    val schemaRegistryAuth              = settingKey[Option[SchemaRegistryAuth]]("Schema registry authentication")
+    val schemaRegistryProperties        = settingKey[Map[String, String]]("Additional schema registry client properties")
 
     lazy val defaultSettings: Seq[Setting[?]] = Seq(
       schemaRegistryUrl           := "http://localhost:8081",
@@ -33,8 +34,8 @@ object SchemaDownloaderPlugin extends AutoPlugin {
   import autoImport.*
 
   override lazy val projectSettings: Seq[Setting[?]] = defaultSettings ++ Seq(
-    schemaRegistryDownload           := (Compile / schemaRegistryDownload).value,
-    Compile / schemaRegistryDownload := {
+    schemaRegistryDownload                    := (Compile / schemaRegistryDownload).value,
+    Compile / schemaRegistryDownload          := {
       val logger   = streams.value.log
       val subjects = schemaRegistrySubjects.value
 
@@ -68,8 +69,8 @@ object SchemaDownloaderPlugin extends AutoPlugin {
         }
       }
     },
-    schemaRegistryRegister           := (Compile / schemaRegistryRegister).value,
-    Compile / schemaRegistryRegister := {
+    schemaRegistryRegister                    := (Compile / schemaRegistryRegister).value,
+    Compile / schemaRegistryRegister          := {
       val logger        = streams.value.log
       val registrations = schemaRegistryRegistrations.value.toList
 
@@ -93,6 +94,35 @@ object SchemaDownloaderPlugin extends AutoPlugin {
           }
 
           if (errors.nonEmpty) sys.error(s"${errors.size} registration(s) failed")
+        }
+      }
+    },
+    schemaRegistryTestCompatibility           := (Compile / schemaRegistryTestCompatibility).value,
+    Compile / schemaRegistryTestCompatibility := {
+      val logger        = streams.value.log
+      val registrations = schemaRegistryRegistrations.value.toList
+
+      if (registrations.isEmpty) {
+        logger.warn("No schema registrations configured. Set schemaRegistryRegistrations to check compatibility.")
+      } else {
+        val client = Downloader.buildClient(
+          rootUrl = schemaRegistryUrl.value,
+          cacheSize = schemaRegistryCacheSize.value,
+          auth = schemaRegistryAuth.value,
+          properties = schemaRegistryProperties.value,
+        )
+        Using.resource(client) { c =>
+          val report = CompatibilityChecker.checkAll(c, registrations)
+
+          report.compatible.foreach(r => logger.info(s"✓ ${r.subject} is compatible"))
+          report.incompatible.foreach { i =>
+            logger.error(s"✗ ${i.subject} is NOT compatible:")
+            i.messages.foreach(m => logger.error(s"    $m"))
+          }
+          report.failed.foreach(f => logger.error(s"⚠ ${f.subject}: ${f.cause.message}"))
+
+          if (!report.isSuccess)
+            sys.error(s"${report.incompatible.size} incompatible, ${report.failed.size} failed")
         }
       }
     },

--- a/src/sbt-test/schema-registry/compatibility-fail/build.sbt
+++ b/src/sbt-test/schema-registry/compatibility-fail/build.sbt
@@ -1,0 +1,10 @@
+import org.galaxio.avro.RegistryRegistration
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion      := "2.12.21",
+    schemaRegistryUrl := RegistryFixture.url,
+    schemaRegistryRegistrations := Seq(
+      RegistryRegistration("it.e2e.CompatFail", baseDirectory.value / "src/main/avro/V1.avsc"),
+    ),
+  )

--- a/src/sbt-test/schema-registry/compatibility-fail/project/RegistryFixture.scala
+++ b/src/sbt-test/schema-registry/compatibility-fail/project/RegistryFixture.scala
@@ -1,0 +1,1 @@
+../../.fixtures/RegistryFixture.scala

--- a/src/sbt-test/schema-registry/compatibility-fail/project/plugins.sbt
+++ b/src/sbt-test/schema-registry/compatibility-fail/project/plugins.sbt
@@ -1,0 +1,1 @@
+../../.fixtures/docker.sbt

--- a/src/sbt-test/schema-registry/compatibility-fail/src/main/avro/V1.avsc
+++ b/src/sbt-test/schema-registry/compatibility-fail/src/main/avro/V1.avsc
@@ -1,0 +1,1 @@
+{"type":"record","name":"CompatFail","namespace":"it.e2e","fields":[{"name":"id","type":"long"}]}

--- a/src/sbt-test/schema-registry/compatibility-fail/src/main/avro/V2-breaking.avsc
+++ b/src/sbt-test/schema-registry/compatibility-fail/src/main/avro/V2-breaking.avsc
@@ -1,0 +1,1 @@
+{"type":"record","name":"CompatFail","namespace":"it.e2e","fields":[{"name":"id","type":"long"},{"name":"name","type":"string"}]}

--- a/src/sbt-test/schema-registry/compatibility-fail/test
+++ b/src/sbt-test/schema-registry/compatibility-fail/test
@@ -1,0 +1,4 @@
+# Register V1, then check compatibility of V2 (breaking removal of required field).
+> Compile / schemaRegistryRegister
+> set schemaRegistryRegistrations := Seq(org.galaxio.avro.RegistryRegistration("it.e2e.CompatFail", baseDirectory.value / "src/main/avro/V2-breaking.avsc"))
+-> Compile / schemaRegistryTestCompatibility

--- a/src/sbt-test/schema-registry/compatibility-pass/build.sbt
+++ b/src/sbt-test/schema-registry/compatibility-pass/build.sbt
@@ -1,0 +1,10 @@
+import org.galaxio.avro.RegistryRegistration
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion      := "2.12.21",
+    schemaRegistryUrl := RegistryFixture.url,
+    schemaRegistryRegistrations := Seq(
+      RegistryRegistration("it.e2e.CompatPass", baseDirectory.value / "src/main/avro/V1.avsc"),
+    ),
+  )

--- a/src/sbt-test/schema-registry/compatibility-pass/project/RegistryFixture.scala
+++ b/src/sbt-test/schema-registry/compatibility-pass/project/RegistryFixture.scala
@@ -1,0 +1,1 @@
+../../.fixtures/RegistryFixture.scala

--- a/src/sbt-test/schema-registry/compatibility-pass/project/plugins.sbt
+++ b/src/sbt-test/schema-registry/compatibility-pass/project/plugins.sbt
@@ -1,0 +1,1 @@
+../../.fixtures/docker.sbt

--- a/src/sbt-test/schema-registry/compatibility-pass/src/main/avro/V1.avsc
+++ b/src/sbt-test/schema-registry/compatibility-pass/src/main/avro/V1.avsc
@@ -1,0 +1,1 @@
+{"type":"record","name":"CompatPass","namespace":"it.e2e","fields":[{"name":"id","type":"long"}]}

--- a/src/sbt-test/schema-registry/compatibility-pass/src/main/avro/V2.avsc
+++ b/src/sbt-test/schema-registry/compatibility-pass/src/main/avro/V2.avsc
@@ -1,0 +1,1 @@
+{"type":"record","name":"CompatPass","namespace":"it.e2e","fields":[{"name":"id","type":"long"},{"name":"name","type":"string","default":""}]}

--- a/src/sbt-test/schema-registry/compatibility-pass/test
+++ b/src/sbt-test/schema-registry/compatibility-pass/test
@@ -1,0 +1,4 @@
+# Register V1, then check compatibility of V2 (backward-compatible addition).
+> Compile / schemaRegistryRegister
+> set schemaRegistryRegistrations := Seq(org.galaxio.avro.RegistryRegistration("it.e2e.CompatPass", baseDirectory.value / "src/main/avro/V2.avsc"))
+> Compile / schemaRegistryTestCompatibility

--- a/src/test/scala/org/galaxio/avro/CompatibilityCheckerSpec.scala
+++ b/src/test/scala/org/galaxio/avro/CompatibilityCheckerSpec.scala
@@ -1,0 +1,140 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.ParsedSchema
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.File
+import java.util.{Collections, Arrays => JArrays}
+
+class CompatibilityCheckerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  private def tempFileWith(content: String): File = {
+    val f = File.createTempFile("compat-", ".avsc")
+    f.deleteOnExit()
+    java.nio.file.Files.write(f.toPath, content.getBytes("UTF-8"))
+    f
+  }
+
+  "CompatibilityChecker.checkOne" should "return Compatible when testCompatibilityVerbose returns empty list" in {
+    val client = mock[SchemaRegistryClient]
+    val f      = tempFileWith("""{"type":"record","name":"Test","fields":[{"name":"id","type":"long"}]}""")
+
+    when(client.testCompatibilityVerbose(eqTo("test-subject"), any[ParsedSchema]()))
+      .thenReturn(Collections.emptyList[String]())
+
+    val result = CompatibilityChecker.checkOne(client, RegistryRegistration("test-subject", f))
+    result shouldBe CompatibilityResult.Compatible("test-subject")
+  }
+
+  it should "return Incompatible with messages when testCompatibilityVerbose returns non-empty list" in {
+    val client = mock[SchemaRegistryClient]
+    val f      = tempFileWith("""{"type":"record","name":"Test","fields":[{"name":"id","type":"long"}]}""")
+
+    when(client.testCompatibilityVerbose(eqTo("test-subject"), any[ParsedSchema]()))
+      .thenReturn(JArrays.asList("new required field has no default value", "field removed"))
+
+    val result       = CompatibilityChecker.checkOne(client, RegistryRegistration("test-subject", f))
+    result shouldBe a[CompatibilityResult.Incompatible]
+    val incompatible = result.asInstanceOf[CompatibilityResult.Incompatible]
+    incompatible.subject shouldBe "test-subject"
+    incompatible.messages should contain allOf ("new required field has no default value", "field removed")
+  }
+
+  it should "return Failed when file does not exist" in {
+    val client = mock[SchemaRegistryClient]
+    val result = CompatibilityChecker.checkOne(
+      client,
+      RegistryRegistration("test-subject", new File("/nonexistent/schema.avsc")),
+    )
+    result shouldBe a[CompatibilityResult.Failed]
+    result.asInstanceOf[CompatibilityResult.Failed].cause shouldBe a[RegistryError.FileNotFound]
+  }
+
+  it should "return Failed when client throws exception" in {
+    val client = mock[SchemaRegistryClient]
+    val f      = tempFileWith("""{"type":"record","name":"Test","fields":[{"name":"id","type":"long"}]}""")
+
+    when(client.testCompatibilityVerbose(eqTo("test-subject"), any[ParsedSchema]()))
+      .thenThrow(new RuntimeException("Connection refused"))
+
+    val result = CompatibilityChecker.checkOne(client, RegistryRegistration("test-subject", f))
+    result shouldBe a[CompatibilityResult.Failed]
+    val failed = result.asInstanceOf[CompatibilityResult.Failed]
+    failed.cause.message should include("Connection refused")
+  }
+
+  it should "return Failed when schema content is invalid" in {
+    val client = mock[SchemaRegistryClient]
+    val f      = tempFileWith("not valid json {{{")
+
+    val result = CompatibilityChecker.checkOne(client, RegistryRegistration("test-subject", f))
+    result shouldBe a[CompatibilityResult.Failed]
+    result.asInstanceOf[CompatibilityResult.Failed].cause shouldBe a[RegistryError.RegistrationFailed]
+  }
+
+  "CompatibilityChecker.checkAll" should "process all subjects independently" in {
+    val client = mock[SchemaRegistryClient]
+    val f1     = tempFileWith("""{"type":"record","name":"A","fields":[{"name":"id","type":"long"}]}""")
+    val f2     = tempFileWith("""{"type":"record","name":"B","fields":[{"name":"id","type":"long"}]}""")
+
+    when(client.testCompatibilityVerbose(eqTo("sub1"), any[ParsedSchema]()))
+      .thenReturn(Collections.emptyList[String]())
+    when(client.testCompatibilityVerbose(eqTo("sub2"), any[ParsedSchema]()))
+      .thenReturn(JArrays.asList("incompatible change"))
+
+    val report = CompatibilityChecker.checkAll(
+      client,
+      List(RegistryRegistration("sub1", f1), RegistryRegistration("sub2", f2)),
+    )
+
+    report.results should have size 2
+    report.compatible should have size 1
+    report.incompatible should have size 1
+    report.failed shouldBe empty
+    report.isSuccess shouldBe false
+  }
+
+  it should "return empty report with isSuccess true for empty registrations" in {
+    val client = mock[SchemaRegistryClient]
+    val report = CompatibilityChecker.checkAll(client, List.empty)
+    report.results shouldBe empty
+    report.isSuccess shouldBe true
+  }
+
+  "CompatibilityReport" should "partition results correctly" in {
+    val report = CompatibilityReport(
+      List(
+        CompatibilityResult.Compatible("a"),
+        CompatibilityResult.Incompatible("b", List("msg")),
+        CompatibilityResult.Failed("c", RegistryError.FileNotFound(new File("x"))),
+        CompatibilityResult.Compatible("d"),
+      ),
+    )
+
+    report.compatible should have size 2
+    report.incompatible should have size 1
+    report.failed should have size 1
+    report.isSuccess shouldBe false
+  }
+
+  it should "report isSuccess true when all compatible" in {
+    val report = CompatibilityReport(
+      List(
+        CompatibilityResult.Compatible("a"),
+        CompatibilityResult.Compatible("b"),
+      ),
+    )
+    report.isSuccess shouldBe true
+  }
+
+  "CompatibilityChecker (empty config)" should "warn and succeed when no registrations configured" in {
+    val client = mock[SchemaRegistryClient]
+    val report = CompatibilityChecker.checkAll(client, List.empty)
+    report.isSuccess shouldBe true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `schemaRegistryTestCompatibility` sbt task that checks local schemas against registry compatibility rules before registration
- Uses `testCompatibilityVerbose` for actionable incompatibility messages (verbose diagnostics)
- Fails the build if any schema is incompatible or check errors — acts as a CI gate before `schemaRegistryRegister`

## New files
- `CompatibilityResult.scala` — sealed ADT: Compatible / Incompatible / Failed
- `CompatibilityReport.scala` — report with lazy partitions + `isSuccess`
- `CompatibilityChecker.scala` — pure `checkOne` / `checkAll` logic
- `CompatibilityCheckerSpec.scala` — 10 unit tests (mocked client)
- `CompatibilityCheckerIntegrationSpec.scala` — 6 integration tests (Testcontainers)
- `compatibility-pass/` + `compatibility-fail/` — scripted e2e tests

## Test plan
- [x] `sbt compile test` — 45 unit tests pass
- [x] `sbt it/test` — 21 integration tests pass (real Schema Registry via Testcontainers)
- [ ] `sbt scripted` — compatibility-pass/fail tests follow same pattern as register-success (CI validates)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)