### PR TITLE
feat: add auto-download of schema references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ sbt scripted                                        # sbt plugin e2e
 
 ## Architecture
 
-Each class owns one responsibility. `SchemaDownloaderPlugin` wires sbt tasks → `Downloader` fetches → `RegistrySubject` (sealed ADT: Pinned/Latest) models subjects → `DownloadError` (sealed ADT) models failures as `Either`. `SchemaRegistryAuth` handles credentials. Inject dependencies; don't construct internally.
+Each class owns one responsibility. `SchemaDownloaderPlugin` wires sbt tasks → `Downloader` fetches → `RegistrySubject` (sealed ADT: Pinned/Latest) models subjects → `DownloadError` (sealed ADT) models failures as `Either`. `SchemaRegistryAuth` handles credentials. `ReferenceResolver` is a pure, tail-recursive BFS that transitively expands schema references (identity = subject+version) via an injected `fetch`; it runs between wildcard-expansion and incremental-skip in the download task. Inject dependencies; don't construct internally.
 
 ## Boundaries
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@ Use AGENTS.md as the primary repository instruction file for this project.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/006-parallel-schema-downloads/plan.md
+at specs/007-resolve-schema-references/plan.md
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -78,21 +78,97 @@ sbt "Compile / schemaRegistryDownload"
 Schema files are saved as `<subject>-<version>.avsc` in `schemaRegistryTargetFolder` (default: `src/main/avro`).
 The build will fail if any schema download fails.
 
-> **Output file behaviour**: every run overwrites existing `.avsc` files unconditionally. There is no
-> incremental caching — the task always fetches the schema from the registry and writes the file afresh.
-> For `RegistrySubject.latest(...)` subjects the version number is resolved at task-run time, so the
+> **Output file behaviour**: by default incremental download is enabled
+> (`schemaRegistryIncremental := true`). The task records downloaded versions in a manifest
+> (`.schema-versions.json` under the project's sbt cache directory) and skips any subject whose
+> version is already current, so unchanged schemas are not re-fetched or re-written. Set
+> `schemaRegistryIncremental := false` to overwrite every file on every run. For
+> `RegistrySubject.latest(...)` subjects the version number is resolved at task-run time, so the
 > output filename (e.g. `my-subject-7.avsc`) may change between runs when the latest version advances.
 
 ## Settings
 
-| Parameter                    | Description                              | Default                |
-|------------------------------|------------------------------------------|------------------------|
-| `schemaRegistrySubjects`     | List of schema subjects with versions    | `Seq()`                |
-| `schemaRegistryUrl`          | URL of the schema registry               | `http://localhost:8081` |
-| `schemaRegistryTargetFolder` | Output directory for downloaded schemas   | `src/main/avro`        |
-| `schemaRegistryCacheSize`    | Schema registry client cache size        | `200`                  |
-| `schemaRegistryAuth`         | Authentication credentials               | `None`                 |
-| `schemaRegistryProperties`   | Additional schema registry client config | `Map.empty`            |
+| Parameter                         | Description                                                       | Default                 |
+|-----------------------------------|------------------------------------------------------------------|-------------------------|
+| `schemaRegistrySubjects`          | List of schema subjects with versions                            | `Seq()`                 |
+| `schemaRegistrySubjectPatterns`   | Regex patterns to match subjects for download                    | `Seq()`                 |
+| `schemaRegistryUrl`               | URL of the schema registry                                       | `http://localhost:8081` |
+| `schemaRegistryTargetFolder`      | Output directory for downloaded schemas                          | `src/main/avro`         |
+| `schemaRegistryCacheSize`         | Schema registry client cache size                                | `200`                   |
+| `schemaRegistryAuth`              | Authentication credentials                                       | `None`                  |
+| `schemaRegistryProperties`        | Additional schema registry client config                         | `Map.empty`             |
+| `schemaRegistryIncremental`       | Enable incremental download — skip unchanged schemas             | `true`                  |
+| `schemaRegistryParallelism`       | Number of concurrent schema downloads (1 = sequential)           | `4`                     |
+| `schemaRegistryRetries`           | Maximum retry attempts for transient download failures (0 = none) | `3`                    |
+| `schemaRegistryResolveReferences` | Auto-download referenced schemas transitively                    | `true`                  |
+
+## Schema References
+
+Schemas can reference other schemas (e.g. an `Order` that embeds a `Customer` type). Confluent
+Schema Registry tracks these references; downloading the referencing schema alone is not enough —
+consumers also need the referenced schemas.
+
+When `schemaRegistryResolveReferences` is `true` (the default), downloading a subject also
+downloads every schema it references, transitively. Each referenced schema is fetched at the
+**exact version** recorded in the reference (pinned, not latest) and written using the normal
+`<subject>-<version>.<ext>` layout, so a single download run produces a complete, self-contained
+set of files.
+
+```sbt
+schemaRegistrySubjects += RegistrySubject.latest("order-value")
+// If order-value references customer-value, both files are downloaded:
+//   src/main/avro/order-value-3.avsc
+//   src/main/avro/customer-value-1.avsc
+```
+
+Resolution is cycle-safe (a reference graph with cycles terminates) and de-duplicates by
+subject+version, so a shared dependency is written once while two genuinely different pinned
+versions of the same subject are written as separate files. The first failed reference fetch fails
+the whole task with an error naming the failing subject.
+
+To download only the explicitly requested subjects (the pre-1.7 behaviour), disable it:
+
+```sbt
+schemaRegistryResolveReferences := false
+```
+
+> **Known limitation**: the incremental-download manifest keys by subject name (one version per
+> subject). If a single run resolves two different versions of the same subject, only the
+> last-written version is recorded, so the other may be re-downloaded (identical bytes) on a
+> later incremental run. This is wasteful but never incorrect, and only affects the rare
+> divergent-version case.
+
+## Download Options
+
+### Wildcard subject patterns
+
+Select subjects by regex instead of (or in addition to) listing them explicitly. Patterns are
+matched against every subject reported by the registry; each match is downloaded at its latest
+version.
+
+```sbt
+schemaRegistrySubjectPatterns := Seq("""order-.*-value""", """.*\.events""")
+```
+
+### Incremental download
+
+Enabled by default. Downloaded versions are tracked in a `.schema-versions.json` manifest under
+the project's sbt cache directory, and subjects already at the current version are skipped.
+Disable to always re-fetch and overwrite:
+
+```sbt
+schemaRegistryIncremental := false
+```
+
+### Parallel downloads
+
+Schemas are fetched concurrently with a bounded thread pool. Tune the degree of concurrency
+(1 = sequential) and the retry budget for transient failures:
+
+```sbt
+schemaRegistryParallelism := 8   // 1..32
+schemaRegistryRetries     := 3   // 0..10, 0 = no retry
+```
 
 ## Schema Registration (Push)
 

--- a/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
@@ -1,0 +1,159 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import io.confluent.kafka.schemaregistry.client.rest.entities.{SchemaReference => ConfluentSchemaReference}
+import org.apache.avro.Schema
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+import sbt.util.Logger
+
+import java.nio.file.{Files, Path}
+import java.util.Collections
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/** End-to-end reference resolution against a real Confluent Schema Registry.
+  *
+  * Validates the parts the pure unit suite stubs: the real `getReferences` mapping (boxed
+  * `Integer`, nullable list) and composition of the resolver output with the existing
+  * incremental and parallel download stages (FR-009).
+  */
+class ReferenceResolutionIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private var network: Network                           = _
+  private var kafka: ConfluentKafkaContainer             = _
+  private var sr: JGenericContainer[_]                   = _
+  private var registryUrl: String                        = _
+  private var registryClient: CachedSchemaRegistryClient = _
+
+  private val silentLogger: Logger = Logger.Null
+
+  override def beforeAll(): Unit = {
+    network = Network.newNetwork()
+
+    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+    kafka.withListener("kafka:19092")
+    kafka.withNetwork(network)
+    kafka.start()
+
+    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
+    sr.withNetwork(network)
+    sr.withExposedPorts(8081)
+    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+    sr.start()
+
+    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
+    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
+  }
+
+  override def afterAll(): Unit = {
+    Option(sr).foreach(c => Try(c.stop()))
+    Option(kafka).foreach(c => Try(c.stop()))
+    Option(network).foreach(c => Try(c.close()))
+  }
+
+  private def avroSchema(json: String): AvroSchema =
+    new AvroSchema(new Schema.Parser().parse(json))
+
+  private def registerWithRefs(subject: String, json: String, refs: List[ConfluentSchemaReference]): Unit = {
+    val schema = new AvroSchema(json, refs.asJava, Collections.emptyMap[String, String](), null)
+    registryClient.register(subject, schema)
+    ()
+  }
+
+  /** The same fetch closure the plugin wires — reads references from a real registry. */
+  private val fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
+    (subject, version) =>
+      Try {
+        val meta = version match {
+          case Some(v) => registryClient.getSchemaMetadata(subject, v)
+          case None    => registryClient.getLatestSchemaMetadata(subject)
+        }
+        val refs = Option(meta.getReferences)
+          .map(_.asScala.toList)
+          .getOrElse(Nil)
+          .map(r => SchemaReference(r.getName, r.getSubject, r.getVersion.intValue))
+        ResolvedSchema(subject, meta.getVersion: Int, refs)
+      }.toEither.left.map(DownloadError.SchemaFetchFailed(subject, _))
+
+  private def withTempDir(test: Path => Any): Unit = {
+    val dir = Files.createTempDirectory("reference-resolution-it")
+    try test(dir)
+    finally Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
+  }
+
+  private val baseJson =
+    """{"type":"record","name":"Base","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
+  private val depJson  =
+    """{"type":"record","name":"Dependent","namespace":"org.galaxio","fields":[{"name":"base_id","type":"long"},{"name":"value","type":"string"}]}"""
+
+  "ReferenceResolver (integration)" should
+    "resolve a referenced schema and download both files (PS-1)" in withTempDir { dir =>
+      val base = "it-rr-base"
+      val dep  = "it-rr-dep"
+      registryClient.register(base, avroSchema(baseJson))
+      registerWithRefs(dep, depJson, List(new ConfluentSchemaReference("Base", base, 1)))
+
+      val expanded = ReferenceResolver.resolve(List(RegistrySubject.latest(dep)), fetch).getOrElse(fail())
+      expanded.map(_.name) should contain allOf (dep, base)
+
+      val downloader = Downloader(registryUrl, dir, silentLogger)
+      try expanded.foreach(s => downloader.schemaSubjectToFile(s) shouldBe a[Right[_, _]])
+      finally downloader.close()
+
+      Files.exists(dir.resolve(s"$dep-1.avsc"))  shouldBe true
+      Files.exists(dir.resolve(s"$base-1.avsc")) shouldBe true
+    }
+
+  it should "fail fast with the failing subject when a fetch fails (PS-4)" in {
+    val result = ReferenceResolver.resolve(List(RegistrySubject.latest("it-rr-missing")), fetch)
+    result shouldBe a[Left[_, _]]
+    val err = result.swap.getOrElse(fail())
+    err                                                       shouldBe a[DownloadError.SchemaFetchFailed]
+    err.asInstanceOf[DownloadError.SchemaFetchFailed].subject shouldBe "it-rr-missing"
+  }
+
+  it should "compose with incremental skip of an already-current reference (PS-5)" in {
+    val base = "it-rr-incr-base"
+    val dep  = "it-rr-incr-dep"
+    registryClient.register(base, avroSchema(baseJson))
+    registerWithRefs(dep, depJson, List(new ConfluentSchemaReference("Base", base, 1)))
+
+    val expanded = ReferenceResolver.resolve(List(RegistrySubject.latest(dep)), fetch).getOrElse(fail())
+
+    val manifest  = VersionManifest(Map(base -> 1))
+    val noLookup: String => Either[DownloadError, Int] =
+      s => Left(DownloadError.SubjectListFailed(new RuntimeException(s"lookup not expected: $s")))
+    val decisions = IncrementalResolver.plan(manifest, expanded, noLookup)
+
+    decisions                                                          should contain(DownloadDecision.Skip(base, 1))
+    decisions.collect { case d: DownloadDecision.Download => d.subject.name } should contain(dep)
+  }
+
+  it should "compose with bounded-parallel download of the expanded list (PS-6)" in withTempDir { dir =>
+    val base = "it-rr-par-base"
+    val dep  = "it-rr-par-dep"
+    registryClient.register(base, avroSchema(baseJson))
+    registerWithRefs(dep, depJson, List(new ConfluentSchemaReference("Base", base, 1)))
+
+    val expanded = ReferenceResolver.resolve(List(RegistrySubject.latest(dep)), fetch).getOrElse(fail())
+
+    val downloader = Downloader(registryUrl, dir, silentLogger)
+    try {
+      val parallel = ParallelDownloader(downloader, 2, RetryPolicy(maxRetries = 0), silentLogger)
+      val results  = parallel.downloadAll(expanded)
+      results.foreach { case (_, r) => r shouldBe a[Right[_, _]] }
+    } finally downloader.close()
+
+    Files.exists(dir.resolve(s"$dep-1.avsc"))  shouldBe true
+    Files.exists(dir.resolve(s"$base-1.avsc")) shouldBe true
+  }
+}

--- a/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
@@ -69,20 +69,11 @@ class ReferenceResolutionIntegrationSpec extends AnyFlatSpec with Matchers with 
     ()
   }
 
-  /** The same fetch closure the plugin wires — reads references from a real registry. */
-  private val fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
-    (subject, version) =>
-      Try {
-        val meta = version match {
-          case Some(v) => registryClient.getSchemaMetadata(subject, v)
-          case None    => registryClient.getLatestSchemaMetadata(subject)
-        }
-        val refs = Option(meta.getReferences)
-          .map(_.asScala.toList)
-          .getOrElse(Nil)
-          .map(r => SchemaReference(r.getName, r.getSubject, r.getVersion.intValue))
-        ResolvedSchema(subject, meta.getVersion: Int, refs)
-      }.toEither.left.map(DownloadError.SchemaFetchFailed(subject, _))
+  /** The exact fetch the plugin wires — reads references from a real registry.
+    * `lazy` so `registryClient` (set in `beforeAll`) is captured after init, not at construction.
+    */
+  private lazy val fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
+    Downloader.referenceFetch(registryClient)
 
   private def withTempDir(test: Path => Any): Unit = {
     val dir = Files.createTempDirectory("reference-resolution-it")

--- a/specs/007-resolve-schema-references/checklists/requirements.md
+++ b/specs/007-resolve-schema-references/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Auto-Download Schema References
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Spec deliberately omits the Scala domain model and `ReferenceResolver` code from issue
+  #31; those are implementation concerns for `/speckit-plan`, not the specification.

--- a/specs/007-resolve-schema-references/contracts/plugin-setting.md
+++ b/specs/007-resolve-schema-references/contracts/plugin-setting.md
@@ -1,0 +1,79 @@
+# Contract: `schemaRegistryResolveReferences` setting + download-task wiring
+
+## New setting (public API — additive)
+
+In `SchemaDownloaderPlugin.autoImport`, beside the existing keys:
+
+```scala
+val schemaRegistryResolveReferences =
+  settingKey[Boolean]("Auto-download schemas referenced by downloaded schemas (transitive)")
+```
+
+Default in `defaultSettings`:
+
+```scala
+schemaRegistryResolveReferences := true,
+```
+
+| Property | Value |
+|----------|-------|
+| Type | `Boolean` |
+| Default | `true` |
+| Scope | build (per-project) |
+| Backward compatibility | additive key only; no rename/removal; no major bump |
+
+## Download-task wiring contract
+
+`Compile / schemaRegistryDownload` gains one stage. Order (research.md Decision 2):
+
+```
+1. SubjectResolver.resolve(client, specs)         -> roots: List[RegistrySubject]   (unchanged)
+2. if (resolveReferences)                          -> expanded                       (NEW)
+     ReferenceResolver.resolve(roots, fetch)
+   else Right(roots)                               (identity pass-through)
+3. IncrementalResolver.plan(manifest, expanded, …) -> decisions                      (unchanged)
+4. ParallelDownloader.downloadAll(toDownload)      -> files                          (unchanged)
+5. manifest update                                                                   (unchanged)
+```
+
+`fetch` closure (shares the existing cached `client`, so stage 4's body fetch is a cache hit):
+
+```scala
+val fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
+  (subject, version) =>
+    Try {
+      val meta = version.fold(client.getLatestSchemaMetadata(subject))(
+        v => client.getByVersion(subject, v, false)
+      )
+      val refs = Option(meta.getReferences).map(_.asScala.toList).getOrElse(Nil)
+        .map(r => SchemaReference(r.getName, r.getSubject, r.getVersion.intValue))
+      ResolvedSchema(subject, meta.getVersion, refs)
+    }.toEither.left.map(DownloadError.SchemaFetchFailed(subject, _))
+```
+
+> Note: confirm the exact body/version accessors against `Downloader.fetchSchema` at
+> implementation time; reuse its proven calls (`getByVersion(name, v, false)` /
+> `getLatestSchemaMetadata(name)`). `getReferences` may be null; `getVersion` is boxed `Integer`.
+
+## Behavioral contract
+
+| ID | Given | When | Then |
+|----|-------|------|------|
+| PS-1 | `resolveReferences := true` (default), subject with a reference | download | both root and referenced files on disk |
+| PS-2 | `resolveReferences := false`, subject with a reference | download | only the root file; output identical to pre-feature (SC-004) |
+| PS-3 | `resolveReferences := true`, subject with no references | download | only that file (acceptance 1.3) |
+| PS-4 | `resolveReferences := true`, a referenced schema fetch fails | download | task fails with `SchemaFetchFailed` naming the subject; no silent partial (FR-008) |
+| PS-5 | resolution + incremental both on, referenced file already current | download | referenced subject skipped by incremental (composes, FR-009) |
+| PS-6 | resolution + parallelism > 1 | download | expanded list downloaded via bounded-concurrency `ParallelDownloader` (FR-009) |
+
+## Test obligations
+
+- **Scripted** `src/sbt-test/schema-registry/resolve-references/`: register a base schema +
+  a dependent schema with a `SchemaReference` (follow existing `register-references` fixture),
+  run `Compile / schemaRegistryDownload`, assert with `$ exists` / `$ must-mirror` that **both**
+  `<base>-1.<ext>` and `<dependent>-1.<ext>` land on disk (PS-1). Add a second test (or a
+  `>set` line) with `schemaRegistryResolveReferences := false` asserting the referenced file is
+  **absent** (PS-2).
+- **Integration** `it/...ReferenceResolutionIntegrationSpec`: Testcontainers Kafka + Schema
+  Registry; register base + dependent-with-reference; drive the resolve+download path; assert
+  both files exist with correct content (PS-1, PS-4 for the failure path).

--- a/specs/007-resolve-schema-references/contracts/plugin-setting.md
+++ b/specs/007-resolve-schema-references/contracts/plugin-setting.md
@@ -36,7 +36,9 @@ schemaRegistryResolveReferences := true,
 5. manifest update                                                                   (unchanged)
 ```
 
-`fetch` closure (shares the existing cached `client`, so stage 4's body fetch is a cache hit):
+`fetch` closure (built by `Downloader.referenceFetch(client)`; shares the existing `client`. Note
+it uses `getSchemaMetadata`, a different call than the download's `getByVersion`, so it adds ~1
+metadata round-trip per schema rather than warming the body fetch):
 
 ```scala
 val fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =

--- a/specs/007-resolve-schema-references/contracts/reference-resolver.md
+++ b/specs/007-resolve-schema-references/contracts/reference-resolver.md
@@ -1,0 +1,72 @@
+# Contract: `ReferenceResolver` (pure core)
+
+New file `src/main/scala/org/galaxio/avro/ReferenceResolver.scala`. Pure, no IO, no client,
+no filesystem. The only effect is the injected `fetch` function.
+
+## Public API
+
+```scala
+object ReferenceResolver {
+
+  /** Transitively resolve all references reachable from `roots`.
+    *
+    * Pure, @tailrec, stack-safe BFS. Roots appear first in the result, followed by
+    * transitively-discovered references (FR-010). Fail-fast: the first Left from `fetch`
+    * short-circuits and is returned unchanged (FR-008).
+    *
+    * Identity is (subject, version): cycle-safe (FR-004) and divergent versions of the
+    * same subject are both kept (spec clarification 2026-06-19).
+    *
+    * @param roots requested subjects (Latest or Pinned) from SubjectResolver
+    * @param fetch (subject, Some(version)=pinned | None=latest) => resolved schema
+    * @return roots-first, deduped list of Pinned subjects, or the first fetch error
+    */
+  def resolve(
+      roots: List[RegistrySubject],
+      fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema],
+  ): Either[DownloadError, List[RegistrySubject]]
+}
+
+final case class ResolvedSchema(
+    subject: String,
+    version: Int,
+    references: List[SchemaReference],
+)
+```
+
+## Behavioral contract
+
+| ID | Given | When | Then |
+|----|-------|------|------|
+| RR-1 | `roots = [A]`, `A` has no refs | resolve | `Right([Pinned(A, vA)])` — single entry, roots-first |
+| RR-2 | `A→B→C` (each pinned) | resolve `[A]` | `Right([Pinned(A,_), Pinned(B,1), Pinned(C,1)])` in BFS order |
+| RR-3 | cycle `A→B→A` | resolve `[A]` | terminates; `A` and `B` each once; no `StackOverflow`; `A` fetched once |
+| RR-4 | shared dep `A→B`, `A→C`, `B→D`, `C→D` | resolve `[A]` | `D` appears exactly once |
+| RR-5 | divergent diamond `A→B@1`, `A→C→B@2` | resolve `[A]` | **both** `Pinned(B,1)` and `Pinned(B,2)` present |
+| RR-6 | `A→MISSING@9`, fetch returns `Left` for MISSING | resolve `[A]` | `Left(SchemaFetchFailed("MISSING", _))`; no further fetches |
+| RR-7 | deep chain depth N (e.g. 50 000) | resolve | completes without `StackOverflow` |
+| RR-8 | root requested `Latest(A)` resolving to vA, also referenced as `A@vA` | resolve | `A` written once (visited key = resolved `(A, vA)`) |
+| RR-9 | `fetch` invocation counter wrapped around stub | resolve cyclic/shared graph | each `(subject, requestedVersion)` fetched at most once (dedup proven, not just output-deduped) |
+
+## Invariants
+
+- **Purity**: same `(roots, fetch)` ⇒ same result. No global state, no clock, no IO.
+- **Stack safety**: recursion is in tail position (`@tailrec` annotation present and compiles).
+- **Ordering**: FIFO `Queue` ⇒ roots before transitive refs (RR-2).
+- **Two-level dedup**: enqueue key `(subject, Option[Int])` (pre-fetch, cycle safety + divergent
+  versions); visited key `(subject, Int)` (post-fetch, result identity). See data-model.md.
+- **Error**: returns existing `DownloadError.SchemaFetchFailed` — no new error type.
+
+## Test obligations (write first — Constitution III)
+
+`src/test/scala/org/galaxio/avro/ReferenceResolverSpec.scala`, `AnyFlatSpec with Matchers`,
+Map-based stub `fetch` (no registry, no mocks):
+
+```scala
+type Key = (String, Option[Int])
+def stub(graph: Map[Key, ResolvedSchema]): (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
+  (s, v) => graph.get((s, v)).toRight(DownloadError.SchemaFetchFailed(s, new RuntimeException("not found")))
+```
+
+Cover RR-1…RR-9. RR-9 wraps the stub in a call counter to prove cycle/shared-dep dedup prevents
+refetch (not just output dedup).

--- a/specs/007-resolve-schema-references/data-model.md
+++ b/specs/007-resolve-schema-references/data-model.md
@@ -1,0 +1,118 @@
+# Phase 1 Data Model: Auto-Download Schema References
+
+Maps the spec's Key Entities onto concrete Scala types — reusing existing ones wherever they
+fit, adding exactly one new value type.
+
+## New types
+
+### `ResolvedSchema` (NEW)
+
+A schema fetched during resolution, carrying just enough to continue the graph walk. Lives in
+`ReferenceResolver.scala` (companion or top-level).
+
+```scala
+final case class ResolvedSchema(
+    subject: String,
+    version: Int,                       // concrete, post-fetch (roots' latest is resolved here)
+    references: List[SchemaReference],  // REUSES existing org.galaxio.avro.SchemaReference
+)
+```
+
+- **Maps to spec entity**: "Resolved Schema".
+- **Why no `content` field**: the resolver only needs the reference graph; bodies are written by
+  the existing `Downloader` in the parallel stage (Decision 4 in research.md). Adding a body
+  here would duplicate `Downloader.writeSchema`. Kept minimal deliberately.
+- **Validation**: `version` is the registry-resolved integer; for referenced schemas it equals
+  the reference's pinned version; for roots requested at latest it is the resolved latest.
+
+## Reused types (no changes)
+
+### `SchemaReference` (REUSE as-is)
+
+```scala
+final case class SchemaReference(name: String, subject: String, version: Int)
+```
+
+Already exactly the spec's "Schema Reference" entity (logical name, target subject, pinned
+version). `version: Int` matches "references always carry a pinned version". **Do not** add the
+issue's proposed `SchemaRef` — it would collide/duplicate.
+
+### `RegistrySubject` (REUSE)
+
+```scala
+sealed trait RegistrySubject { def name: String }
+object RegistrySubject {
+  final case class Pinned(name: String, version: Int) extends RegistrySubject
+  final case class Latest(name: String)               extends RegistrySubject
+}
+```
+
+Resolver **output** is `List[RegistrySubject.Pinned]` (every resolved node pinned to its concrete
+version). When resolution is disabled, the original roots (possibly `Latest`) pass through
+unchanged.
+
+### `DownloadError` (REUSE — no new case)
+
+Fail-fast uses the existing case:
+
+```scala
+final case class SchemaFetchFailed(subject: String, error: Throwable) extends DownloadError
+```
+
+The injected `fetch` returns `Left(SchemaFetchFailed(subject, cause))`; the resolver propagates
+it unchanged (FR-008). No new error case is introduced.
+
+## Identity & dedup keys (the crux)
+
+Two **distinct** keys (research.md Decision 3) — conflating them is the canonical bug:
+
+| Key | Type | Recorded | Role |
+|-----|------|----------|------|
+| Enqueue key | `(String, Option[Int])` — *requested* identity (`None` = latest) | before fetch | prevents re-enqueue; cycle safety; keeps divergent versions (`B@1` vs `B@2` distinct) |
+| Visited key | `(String, Int)` — *resolved* identity | after fetch | result dedup (shared deps); equals filename stem `subject-version` |
+
+- **Spec identity rule** (clarification 2026-06-19): a resolved schema is identified by
+  **subject + version**. The visited key is that identity.
+- **Divergent diamond** (`A→B@1`, `A→C→B@2`): distinct enqueue keys → both fetched → distinct
+  visited keys → both in output → `B-1.ext` and `B-2.ext` both written.
+- **Cycle** (`A↔B`): `B`'s back-edge to `A` is dropped at enqueue (A already enqueued) → loop
+  terminates, `A` fetched once.
+- **Shared dep** (`A→B`, `A→C`, `B→D`, `C→D`): second `D` skipped at enqueue/visited → `D`
+  written once.
+
+## State / flow
+
+```
+roots: List[RegistrySubject]            (from SubjectResolver — Exact + pattern-matched)
+        │
+        ▼  ReferenceResolver.resolve(roots, fetch)   [pure, @tailrec BFS]
+        │     queue: Queue[(subject, Option[Int])]
+        │     enqueued: Set[(String, Option[Int])]   (pre-fetch dedup)
+        │     visited:  Set[(String, Int)]           (post-fetch dedup)
+        │     acc:      Vector[RegistrySubject.Pinned]  (roots-first)
+        ▼
+expanded: List[RegistrySubject.Pinned]  (roots first, then transitive refs, deduped)
+        │
+        ▼  IncrementalResolver.plan(manifest, expanded, registryVersions)  [unchanged]
+        ▼  ParallelDownloader.downloadAll(toDownload)                       [unchanged]
+        ▼  files: <subject>-<version>.<ext>   +   manifest update
+```
+
+`fetch` signature (injected at the plugin call site, closure over the shared cached client):
+
+```scala
+fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema]
+// version = None  -> client.getLatestSchemaMetadata(subject)
+// version = Some(v) -> client.getByVersion(subject, v, false)
+// references via Option(meta.getReferences).map(_.asScala.toList).getOrElse(Nil)
+//                  .map(r => SchemaReference(r.getName, r.getSubject, r.getVersion.intValue))
+```
+
+## Relationships
+
+- `ResolvedSchema.references : List[SchemaReference]` — children to enqueue.
+- `SchemaReference.subject + version` — becomes the next `(subject, Some(version))` enqueue key
+  and, post-fetch, a `RegistrySubject.Pinned` output entry.
+- Output `RegistrySubject.Pinned.name + version` — becomes the download filename stem and the
+  incremental-manifest comparison key (subject-name only on the manifest side — see known
+  limitation in research.md Decision 4).

--- a/specs/007-resolve-schema-references/plan.md
+++ b/specs/007-resolve-schema-references/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Auto-Download Schema References
+
+**Branch**: `007-resolve-schema-references` | **Date**: 2026-06-19 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/007-resolve-schema-references/spec.md`
+
+## Summary
+
+Add transitive resolution of schema references to the download task. When a downloaded
+schema declares references (Confluent `SchemaMetadata.getReferences`), the plugin walks the
+reference graph and downloads every dependency, pinned to its exact version. Resolution is a
+**new pipeline stage** inserted between wildcard-expansion and incremental-skip:
+`wildcard-expand → resolve-references → incremental-skip → parallel-fetch+write`.
+
+The core is a **pure, `@tailrec`, stack-safe BFS resolver** (`ReferenceResolver`) that takes
+an injected `fetch` function and returns `Either[DownloadError, List[RegistrySubject]]`
+(roots first, then transitive refs, all `Pinned`). Identity is **subject+version** (per spec
+clarification 2026-06-19): a two-level dedup keeps the resolver both cycle-safe and able to
+keep divergent versions of the same subject. A new boolean setting
+`schemaRegistryResolveReferences` (default `true`) gates the stage; when `false` it is an
+identity pass-through, preserving today's behavior byte-for-byte.
+
+## Technical Context
+
+**Language/Version**: Scala 2.12.21 (sbt plugin Scala)
+
+**Primary Dependencies**: Confluent `kafka-schema-registry-client` 8.2.1 (already pinned in
+`project/Dependencies.scala`); no cats dependency (project uses right-biased `scala.Either`)
+
+**Storage**: Filesystem — schema files written as `<subject>-<version>.<ext>` to
+`schemaRegistryTargetFolder`; incremental manifest `.schema-versions.json`
+
+**Testing**: ScalaTest `AnyFlatSpec` + Matchers + mockito-scala (unit); Testcontainers
+(Confluent Kafka + Schema Registry) for `it/` integration; sbt `scripted` for plugin e2e
+
+**Target Platform**: JVM (Java 17+), consumed as an sbt 1.12.x autoplugin
+
+**Project Type**: Single-project sbt plugin (library/build-tool)
+
+**Performance Goals**: Reference graph walk is sequential metadata fetches warmed by the
+shared `CachedSchemaRegistryClient`; bulk body download stays parallel via the existing
+`ParallelDownloader`. No new performance target beyond "resolution adds no second network
+round-trip per schema thanks to the shared client cache."
+
+**Constraints**: Compile with `-Xfatal-warnings` (no warnings); `scalafmtAll` +
+`scalafmtSbt` must pass; backward-compatible public API (additive keys only); resolver must
+be pure and stack-safe for deep chains; fail-fast on first fetch error.
+
+**Scale/Scope**: One new pure class (`ReferenceResolver`) + one new value type
+(`ResolvedSchema`) + one new setting; ~3 edited files (`SchemaDownloaderPlugin`, plus reuse
+of `Downloader`/`SchemaReference`/`DownloadError`). Reference graphs in practice are small
+(tens of nodes); design is correct for arbitrary depth and cycles.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment | Status |
+|-----------|-----------|--------|
+| I. Backward Compatibility | Only additive public surface: one new `settingKey` (`schemaRegistryResolveReferences`, default `true`). No task/key renamed or removed. Opt-out (`:= false`) restores prior behavior exactly (SC-004). New default changes *output* (extra files appear) but not *API*; treated as additive enhancement per spec Assumptions. No major bump required. | ✅ PASS |
+| II. Single Responsibility | `ReferenceResolver` owns graph traversal only (no IO, no client, no `Files`). `ResolvedSchema` models fetched-schema data. Existing `SchemaReference`, `DownloadError.SchemaFetchFailed`, `RegistrySubject.Pinned`, `Downloader`, `ParallelDownloader`, `IncrementalResolver` are reused, not duplicated. The `fetch` effect is **injected** (function arg), never constructed internally — mirrors `IncrementalResolver`'s `registryVersions` seam. | ✅ PASS |
+| III. Test-First | Tests precede implementation: `ReferenceResolverSpec` (pure, Map-stub fetch: transitive, cycle, shared-dep, divergent diamond, fail-fast, fetch-count proof); `it/` integration registers a schema with a reference then downloads root and asserts both files on disk; sbt `scripted` `resolve-references` test for plugin wiring. No mocking of Schema Registry HTTP where a real path exists (integration uses Testcontainers). | ✅ PASS |
+| IV. Trunk-Based Release | Work proceeds on a feature branch off `main` (`007-resolve-schema-references`); no version reuse, no direct `main` commits, rebase-only. | ✅ PASS |
+| V. Format & Verify | `scalafmtAll`/`scalafmtSbt` before commit; new code compiles under `-Xfatal-warnings`. Confluent `getVersion(): java.lang.Integer` unboxed explicitly to avoid warnings/NPE. | ✅ PASS |
+
+**Result**: No violations. Complexity Tracking table left empty.
+
+### Post-Design Re-check (after Phase 1)
+
+Design introduces exactly one new class, one new value type, one new setting; all other
+behavior reuses existing components. The one acknowledged compromise — the subject-keyed
+`VersionManifest` cannot track two versions of one subject, so a divergent-version schema
+may be redundantly re-written on later runs (never incorrect) — is documented as a known
+limitation and a follow-up, **not** smuggled into this feature as a manifest-format change.
+This *preserves* Single Responsibility (no manifest redesign here) rather than violating it.
+Constitution Check still **PASS**; no entries needed in Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-resolve-schema-references/
+├── spec.md              # Feature specification (input)
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 output — decisions on API, ordering, resolver pattern
+├── data-model.md        # Phase 1 output — ResolvedSchema, identity keys, reuse map
+├── quickstart.md        # Phase 1 output — runnable validation scenarios
+├── contracts/
+│   ├── reference-resolver.md   # Pure resolver API contract + dedup semantics
+│   └── plugin-setting.md       # schemaRegistryResolveReferences setting contract
+└── checklists/
+    └── requirements.md  # Spec quality checklist (from /speckit-specify)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/avro/
+├── ReferenceResolver.scala      # NEW — pure @tailrec BFS resolver + ResolvedSchema
+├── SchemaDownloaderPlugin.scala # EDIT — new setting + insert resolve stage in download task
+├── SchemaReference.scala        # REUSE as-is — (name, subject, version: Int) reference entity
+├── Downloader.scala             # REUSE — fetchSchema is the model for the injected fetch;
+│                                #         filename scheme already subject+version
+├── DownloadError.scala          # REUSE — SchemaFetchFailed covers fetch failures (fail-fast)
+├── RegistrySubject.scala        # REUSE — emit refs as RegistrySubject.Pinned
+├── IncrementalResolver.scala    # REUSE unchanged — operates on the expanded list
+└── ParallelDownloader.scala     # REUSE unchanged — downloads the expanded list in parallel
+
+src/test/scala/org/galaxio/avro/
+└── ReferenceResolverSpec.scala  # NEW — pure unit tests with Map-based stub fetch
+
+it/src/test/scala/org/galaxio/avro/
+└── ReferenceResolutionIntegrationSpec.scala  # NEW — Testcontainers: register ref → download → verify files
+
+src/sbt-test/schema-registry/
+└── resolve-references/          # NEW — scripted e2e: build.sbt + test + project/plugins.sbt
+    ├── build.sbt
+    ├── test
+    └── project/plugins.sbt
+```
+
+**Structure Decision**: Single-project sbt plugin (matches existing `org.galaxio.avro`
+layout). The only new production file is `ReferenceResolver.scala`; everything else either
+reuses an existing type or edits the single wiring point (`SchemaDownloaderPlugin`). Tests
+follow the established three-tier convention (unit / `it` Testcontainers / `scripted`).
+
+## Complexity Tracking
+
+> No Constitution violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/007-resolve-schema-references/plan.md
+++ b/specs/007-resolve-schema-references/plan.md
@@ -37,10 +37,11 @@ identity pass-through, preserving today's behavior byte-for-byte.
 
 **Project Type**: Single-project sbt plugin (library/build-tool)
 
-**Performance Goals**: Reference graph walk is sequential metadata fetches warmed by the
-shared `CachedSchemaRegistryClient`; bulk body download stays parallel via the existing
-`ParallelDownloader`. No new performance target beyond "resolution adds no second network
-round-trip per schema thanks to the shared client cache."
+**Performance Goals**: Reference graph walk is sequential metadata fetches; bulk body download
+stays parallel via the existing `ParallelDownloader`. Resolution adds roughly one metadata REST
+round-trip per schema (its `getSchemaMetadata` call is not served from the download fetch's
+id-keyed cache) — acceptable because graphs are small and resolution runs once. No new
+performance target.
 
 **Constraints**: Compile with `-Xfatal-warnings` (no warnings); `scalafmtAll` +
 `scalafmtSbt` must pass; backward-compatible public API (additive keys only); resolver must

--- a/specs/007-resolve-schema-references/quickstart.md
+++ b/specs/007-resolve-schema-references/quickstart.md
@@ -1,0 +1,89 @@
+# Quickstart: Auto-Download Schema References
+
+Validation guide proving feature 007 end-to-end. Details live in
+[data-model.md](data-model.md), [contracts/](contracts/), [research.md](research.md).
+
+## Prerequisites
+
+- JDK 17+, sbt 1.12.x
+- Docker (for `it/test` Testcontainers and the `scripted` registry fixture)
+- Repo builds clean today: `sbt compile`
+
+## User-facing usage
+
+In a consuming `build.sbt`:
+
+```scala
+schemaRegistryUrl     := "http://localhost:8081"
+schemaRegistrySubjects := Seq(RegistrySubject.latest("order-value"))
+// schemaRegistryResolveReferences := true   // default — referenced schemas auto-downloaded
+```
+
+Run `sbt "Compile / schemaRegistryDownload"`. If `order-value` references `customer-value`,
+both `order-value-<v>.avsc` and `customer-value-<v>.avsc` appear in
+`schemaRegistryTargetFolder`. Set `schemaRegistryResolveReferences := false` to download only
+the requested subjects (prior behavior).
+
+## Validation scenarios
+
+### 1. Unit — pure resolver (fast, no Docker)
+
+```bash
+sbt "testOnly org.galaxio.avro.ReferenceResolverSpec"
+```
+
+**Expected**: all cases green — transitive `A→B→C` (RR-2), cycle `A↔B` terminates (RR-3),
+shared dep once (RR-4), divergent diamond keeps both `B@1`+`B@2` (RR-5), fail-fast (RR-6),
+deep-chain no SOE (RR-7), latest/pinned reconciliation (RR-8), fetch-count dedup proof (RR-9).
+See [contracts/reference-resolver.md](contracts/reference-resolver.md).
+
+### 2. Scripted — plugin e2e (Docker)
+
+```bash
+sbt "scripted schema-registry/resolve-references"
+```
+
+**Expected**: registers a base + dependent-with-reference schema, runs the download task, and
+the script asserts (`$ exists` / `$ must-mirror`) that **both** files are on disk (PS-1). The
+opt-out path asserts the referenced file is absent when
+`schemaRegistryResolveReferences := false` (PS-2).
+
+### 3. Integration — real registry (Docker)
+
+```bash
+sbt "it/testOnly org.galaxio.avro.ReferenceResolutionIntegrationSpec"
+```
+
+**Expected**: Testcontainers Kafka + Schema Registry; a dependent schema with a reference is
+registered; resolve+download produces both files with correct content; a missing reference
+fails fast with `SchemaFetchFailed` (PS-4).
+
+### 4. Backward-compat regression
+
+```bash
+sbt "scripted schema-registry/download-success"   # existing test, must stay green
+```
+
+**Expected**: unchanged — a subject with no references still yields exactly one file
+(acceptance 1.3 / SC-004).
+
+## Full gate (Constitution V)
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck "compile" "test"
+sbt "it/test"        # Docker
+sbt scripted         # Docker
+```
+
+All must pass under `-Xfatal-warnings`.
+
+## Done signals (map to spec)
+
+| Check | Spec |
+|-------|------|
+| Transitive files on disk in one run | SC-001, FR-002 |
+| Referenced files at pinned version | SC-002, FR-003 |
+| Cycle/shared/divergent terminate, each subject+version once | SC-003, FR-004/FR-005 |
+| `:= false` ⇒ byte-identical to prior | SC-004, FR-007 |
+| Missing reference ⇒ named error | SC-005, FR-008 |
+| Composes with wildcard/incremental/parallel | FR-009 |

--- a/specs/007-resolve-schema-references/research.md
+++ b/specs/007-resolve-schema-references/research.md
@@ -58,12 +58,16 @@ manifest-update**.
   incremental order.
 - *Before parallel-fetch*: the content-writing stage must see the complete expanded list.
 
-**Double-fetch tension**: resolution fetches metadata to read references; download fetches the
-body. Both share the **same `CachedSchemaRegistryClient` instance** (threaded through
-`withRegistryClient`, default cache 200). `getByVersion(subject, version, …)` is cached by
-(subject, version), so resolution warms the cache and the download fetch is a cache hit. No new
-caching layer — requirement is only "resolution and download share one client," which current
-wiring already satisfies.
+**Double-fetch tension**: resolution fetches metadata (`getSchemaMetadata` /
+`getLatestSchemaMetadata`) to read references; download fetches the body
+(`getByVersion(subject, version, false)`). These are *different* client methods, and
+`CachedSchemaRegistryClient`'s cache is keyed on schema↔id mappings, **not** on version
+metadata — so in practice resolution adds roughly one metadata REST round-trip per schema on
+top of the download fetch. This is acceptable: reference graphs are small (tens of nodes) and
+resolution runs once, sequentially, before the parallel body download. We deliberately do **not**
+fold bodies into resolution to save that round-trip (see Decision 4) — the clean stage separation
+is worth more than one small GET per schema. Both stages do share the one client instance
+(threaded through `withRegistryClient`), so id-keyed cache hits still help where applicable.
 
 **Insertion point**: `SchemaDownloaderPlugin.scala`, between `SubjectResolver.resolve` (~line 127)
 and `loadManifest` / `IncrementalResolver.plan` (~line 129–139).
@@ -132,8 +136,8 @@ subject corner is sub-optimal.
 
 **Alternative considered**: have `ResolvedSchema` also carry the body and bypass the download
 fetch (rejected — would duplicate `Downloader.writeSchema`, and either serialize writes (lose
-parallelism) or re-plumb parallelism into the resolver (lose purity); the shared cache already
-removes the network cost of the second fetch).
+parallelism) or re-plumb parallelism into the resolver (lose purity)). It would save the ~1
+metadata round-trip per schema, but the clean stage separation is worth more than that.
 
 ## Decision 5 — Setting & backward compatibility
 
@@ -156,7 +160,7 @@ bump).
 | Reference API surface | `SchemaMetadata.getReferences()` → `rest.entities.SchemaReference` (Decision 1) |
 | `getVersion` type | boxed `Integer` in 8.2.1 — unbox explicitly (Decision 1) |
 | Where resolution runs | new stage between expand and skip (Decision 2) |
-| Avoiding double network fetch | shared `CachedSchemaRegistryClient` (Decision 2) |
+| Double fetch cost | ~1 metadata round-trip per schema (not cached); accepted, graphs small (Decision 2) |
 | Cycle + divergent-version correctness | two-level dedup: enqueue `(subj,Option[Int])` / visited `(subj,Int)` (Decision 3) |
 | New error type? | No — reuse `DownloadError.SchemaFetchFailed` (Decision 3) |
 | Output type | `List[RegistrySubject.Pinned]`, roots-first (Decision 4) |

--- a/specs/007-resolve-schema-references/research.md
+++ b/specs/007-resolve-schema-references/research.md
@@ -1,0 +1,166 @@
+# Phase 0 Research: Auto-Download Schema References
+
+All findings grounded in the actual codebase (`org.galaxio.avro`, Scala 2.12.21,
+`kafka-schema-registry-client` 8.2.1) and verified against the pinned 8.2.1 jar via `javap`.
+
+## Decision 1 — Confluent references API
+
+**Decision**: Read references off `SchemaMetadata.getReferences()`, obtained from the methods
+the codebase already uses:
+
+```java
+SchemaMetadata getSchemaMetadata(String subject, int version)   // pinned ref
+SchemaMetadata getLatestSchemaMetadata(String subject)          // latest root
+// on SchemaMetadata:
+java.util.List<io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference> getReferences()
+// on rest.entities.SchemaReference:
+String getName();  String getSubject();  java.lang.Integer getVersion();
+```
+
+**Rationale**: `Downloader.scala` already calls `getLatestSchemaMetadata` /
+`client.getByVersion(name, version, false)`; references currently arrive on those results and
+are simply dropped. Mapping to the repo's own `SchemaReference(name, subject, version: Int)`
+needs only the three accessors.
+
+**Critical correction (verified via `javap` on 8.2.1)**: `SchemaReference.getVersion()`
+returns **boxed `java.lang.Integer`, not `int`**. Unbox explicitly to avoid NPE and
+`-Xfatal-warnings` issues:
+`Option(r.getVersion).map(_.intValue).getOrElse(...)` or, since refs are always pinned,
+`r.getVersion.intValue`. Also treat `getReferences()` as **possibly null** —
+`Option(meta.getReferences).map(_.asScala.toList).getOrElse(Nil)`.
+
+**Conversion**: Scala 2.12 → use `import scala.collection.JavaConverters._` then `.asScala.toList`
+(NOT `scala.jdk.CollectionConverters`, which is 2.13+). This matches the existing convention in
+`SubjectResolver.scala`, `CompatibilityChecker.scala`, `VersionManifest.scala`.
+
+**Alternatives considered**: `scala.jdk.CollectionConverters` (rejected — won't compile on
+2.12); `getSchemaMetadata(subject, version, lookupDeleted)` 3-arg overload (unnecessary);
+folding bodies into resolution to avoid a second fetch (rejected — see Decision 4).
+
+**Verify at implementation time** (cannot run build here):
+```bash
+JAR=~/Library/Caches/Coursier/v1/https/packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/8.2.1/kafka-schema-registry-client-8.2.1.jar
+javap -cp "$JAR" io.confluent.kafka.schemaregistry.client.SchemaMetadata
+javap -cp "$JAR" io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
+```
+
+## Decision 2 — Pipeline placement
+
+**Decision**: Resolution is a **new second stage**, between wildcard-expand and incremental-skip.
+Final order: **wildcard-expand → resolve-references → incremental-skip → parallel-fetch+write →
+manifest-update**.
+
+**Rationale**:
+- *After wildcard-expand*: references can't be discovered until patterns become concrete roots.
+- *Before incremental-skip*: skip drops subject+versions already on disk. If skip ran first, a
+  cached root would never be fetched and its references never discovered → silently lost
+  transitive deps. "Discover full closure, then decide what's stale" is the only complete +
+  incremental order.
+- *Before parallel-fetch*: the content-writing stage must see the complete expanded list.
+
+**Double-fetch tension**: resolution fetches metadata to read references; download fetches the
+body. Both share the **same `CachedSchemaRegistryClient` instance** (threaded through
+`withRegistryClient`, default cache 200). `getByVersion(subject, version, …)` is cached by
+(subject, version), so resolution warms the cache and the download fetch is a cache hit. No new
+caching layer — requirement is only "resolution and download share one client," which current
+wiring already satisfies.
+
+**Insertion point**: `SchemaDownloaderPlugin.scala`, between `SubjectResolver.resolve` (~line 127)
+and `loadManifest` / `IncrementalResolver.plan` (~line 129–139).
+
+**Alternatives considered**: resolve inside `Downloader.schemaSubjectToFile` (rejected — runs
+in parallel fan-out, explodes registry load, can't expand the work-list); resolve inside
+`SubjectResolver` (rejected — `SubjectResolver` needs the client only for `getAllSubjects`;
+mixing reference traversal there violates single responsibility).
+
+## Decision 3 — Pure resolver pattern (two-level dedup)
+
+**Decision**: A pure `@tailrec` BFS over an immutable FIFO `Queue`, with **two distinct dedup
+keys** — the single most important correctness point:
+
+| Key | Type | Recorded | Purpose |
+|-----|------|----------|---------|
+| **Enqueue key** | `(subject, Option[Int])` requested identity | *before* fetch, at enqueue | stop re-queuing same work; cycle-safe before resolved versions are known |
+| **Visited key** | `(subject, Int)` resolved | *after* fetch | result identity; dedup shared deps; matches filename/spec identity |
+
+**Rationale**:
+- A root requested at *latest* (`None`) resolves to a concrete version only **after** `fetch`.
+  Keying the visited set on the request would make `None` and `Some(7)` look like different
+  nodes → double-fetch/loop. So visited must key on the **resolved** `(subject, Int)`.
+- Cycles (`A↔B`) must terminate **before** versions are known → the **enqueue** key (checked
+  pre-fetch) is what guarantees cycle safety.
+- Per spec clarification (identity = subject+version, divergent diamond keeps **both** B@1 and
+  B@2), the enqueue key is the **requested identity `(subject, Option[Int])`**, not bare
+  subject. This is the "divergent-version policy" — `B@1` and `B@2` are distinct enqueue keys,
+  both fetched, both kept. (Bare-subject enqueue dedup would collapse them — rejected, would
+  violate the clarified identity rule.)
+- `@tailrec` with `(queue, enqueued, visited, acc)` compiles to a `while` loop → stack-safe for
+  deep chains (FR-002, deep-chain edge case). `acc` is a `Vector` (O(1) append), `.toList` once
+  at the end.
+- FIFO `Queue` ⇒ BFS ⇒ roots appear before transitive refs (FR-010).
+- Fail-fast: first `Left` from `fetch` short-circuits the loop (FR-008), reusing
+  `DownloadError.SchemaFetchFailed(subject, cause)` — **no new error type needed**.
+
+**Error model & effects**: stdlib right-biased `Either` (no cats in repo). The only effect is
+the injected `fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema]`; the
+resolver imports no client and touches no filesystem. This mirrors `IncrementalResolver`'s
+`registryVersions: String => Either[DownloadError, Int]` seam → unit-testable with a Map stub.
+
+**Alternatives considered**: DFS via List/stack (rejected — breaks roots-first ordering, deeper
+recursion); single visited key (rejected — the classic bug, either loops on cycles or
+double-fetches latest-vs-pinned); `Validated`/error accumulation (rejected — spec wants
+fail-fast); `EitherT`/`F[_]` (rejected — `fetch` is synchronous, monad transformers add noise).
+
+## Decision 4 — Output shape & dedup mapping
+
+**Decision**: Resolver returns `Either[DownloadError, List[RegistrySubject]]` where every entry
+is `RegistrySubject.Pinned(subject, resolvedVersion)` (refs always pinned; roots pinned to their
+resolved version), roots first. Identity `(subject, version)` maps **directly** onto:
+- **Filename** `s"$subject-$version.$ext"` (already subject+version) → "write each subject+version
+  once" = "write each filename once". Divergent diamond writes `customer-value-1.avsc` and
+  `customer-value-2.avsc` as distinct files, no collision, no special handling.
+- **Incremental-skip**: the expanded `Pinned` list flows through `IncrementalResolver.plan`
+  unchanged.
+
+**Known limitation (flagged, follow-up — NOT in 007)**: `VersionManifest` keys by
+**subject-name only** (one version per subject). When two versions of the same subject are
+resolved, the manifest can record only the last-written one, so the other may be **redundantly
+re-downloaded on a subsequent run** (a wasteful write of identical bytes — never incorrect).
+Widening the manifest key to subject+version is a manifest-format change and belongs in its own
+feature. Resolution still composes with incremental (FR-009); only the multi-version-of-one-
+subject corner is sub-optimal.
+
+**Alternative considered**: have `ResolvedSchema` also carry the body and bypass the download
+fetch (rejected — would duplicate `Downloader.writeSchema`, and either serialize writes (lose
+parallelism) or re-plumb parallelism into the resolver (lose purity); the shared cache already
+removes the network cost of the second fetch).
+
+## Decision 5 — Setting & backward compatibility
+
+**Decision**: Add `schemaRegistryResolveReferences = settingKey[Boolean]("...")`, default
+`true`, beside the existing toggles in `defaultSettings`. When `false`, the stage is an identity
+pass-through (`roots => Right(roots)`) → behavior byte-for-byte identical to today (SC-004).
+
+**Rationale / additive proof**: With `true` (new default), a subject **with** references now
+*additionally* yields the referenced files; existing files are unchanged (same name, content,
+location). A subject with **no** references produces identical output to today (acceptance 1.3).
+Opt-out restores prior behavior exactly (FR-007, User Story 2). Matches existing capability
+toggles (`schemaRegistryIncremental`, `schemaRegistryParallelism`, `schemaRegistryRetries`) in
+style and default-on philosophy. Backward-compatible per Constitution I (additive key, no major
+bump).
+
+## Resolved unknowns
+
+| Unknown | Resolution |
+|---------|-----------|
+| Reference API surface | `SchemaMetadata.getReferences()` → `rest.entities.SchemaReference` (Decision 1) |
+| `getVersion` type | boxed `Integer` in 8.2.1 — unbox explicitly (Decision 1) |
+| Where resolution runs | new stage between expand and skip (Decision 2) |
+| Avoiding double network fetch | shared `CachedSchemaRegistryClient` (Decision 2) |
+| Cycle + divergent-version correctness | two-level dedup: enqueue `(subj,Option[Int])` / visited `(subj,Int)` (Decision 3) |
+| New error type? | No — reuse `DownloadError.SchemaFetchFailed` (Decision 3) |
+| Output type | `List[RegistrySubject.Pinned]`, roots-first (Decision 4) |
+| Incremental interaction | composes; subject-keyed manifest divergent-version corner is a flagged follow-up (Decision 4) |
+| Setting name/default | `schemaRegistryResolveReferences`, default `true` (Decision 5) |
+
+No `[NEEDS CLARIFICATION]` markers remain.

--- a/specs/007-resolve-schema-references/spec.md
+++ b/specs/007-resolve-schema-references/spec.md
@@ -1,0 +1,186 @@
+# Feature Specification: Auto-Download Schema References
+
+**Feature Branch**: `007-resolve-schema-references`
+
+**Created**: 2026-06-19
+
+**Status**: Draft
+
+**Input**: GitHub issue [#31](https://github.com/galax-io/sbt-schema-registry-plugin/issues/31): "feat: auto-download schema references"
+
+## Clarifications
+
+### Session 2026-06-19
+
+- Q: Dedup / identity key for resolved schemas (cycle protection + write-once)? → A: Key by **subject + version**. Distinct pinned versions of the same subject are all downloaded and written as separate files (`customer-value-1.avsc`, `customer-value-2.avsc`); cycle protection skips a re-visit of the same subject+version. This supersedes issue #31's `Set[String]` (subject-only) sketch, which predates the version-in-filename convention.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Transitive reference download (Priority: P1)
+
+A developer downloads a schema (e.g., `order-value`) that references another schema
+(e.g., `customer-value`). The plugin automatically detects the reference, downloads the
+referenced schema too, and continues transitively until every dependency is on disk.
+The developer ends up with a complete, self-contained set of schema files without having
+to manually list each dependency.
+
+**Why this priority**: This is the core value of the feature. Without transitive
+resolution, a downloaded schema that depends on others is unusable — consumers cannot
+deserialize messages because the referenced types are missing. This single story
+delivers the entire MVP.
+
+**Independent Test**: Register a root schema with a reference to a second schema, run the
+download task for the root subject only, and verify both schema files appear on disk with
+correct content.
+
+**Acceptance Scenarios**:
+
+1. **Given** subject `order-value` references `customer-value`, **When** the developer
+   downloads `order-value`, **Then** both `order-value` and `customer-value` are written
+   to disk.
+2. **Given** a chain `A → B → C` where A references B and B references C, **When** the
+   developer downloads A, **Then** all three schemas (A, B, C) are written to disk.
+3. **Given** a subject with no references, **When** the developer downloads it, **Then**
+   only that one schema is written and behavior is identical to today.
+
+---
+
+### User Story 2 - Opt-out of reference resolution (Priority: P2)
+
+A developer wants to download only the explicitly requested subjects without pulling in
+referenced schemas (for example, when references are managed separately or already
+vendored). They disable reference resolution via a setting and the plugin downloads only
+the requested subjects.
+
+**Why this priority**: Auto-resolution is the right default, but some workflows need the
+previous behavior. Providing an explicit toggle preserves backward compatibility and user
+control. Secondary to the core resolution capability.
+
+**Independent Test**: Set the resolve-references toggle to off, download a subject that has
+references, and verify only the requested subject is written and no referenced schemas are
+fetched.
+
+**Acceptance Scenarios**:
+
+1. **Given** reference resolution is disabled, **When** the developer downloads a subject
+   with references, **Then** only the requested subject is written to disk.
+2. **Given** reference resolution is enabled (the default), **When** the developer
+   downloads a subject with references, **Then** referenced schemas are written too.
+
+---
+
+### User Story 3 - Safe handling of cyclic and shared references (Priority: P3)
+
+A developer downloads schemas whose reference graph contains cycles (A references B and B
+references A) or shared dependencies (both A and B reference C). The plugin completes
+without looping forever and without downloading or writing the same schema twice.
+
+**Why this priority**: Cycles and shared dependencies are real in mature schema
+ecosystems. Correctness here prevents hangs and duplicate work, but it is a robustness
+concern layered on top of the core resolution capability.
+
+**Independent Test**: Construct a reference graph with a cycle and a shared dependency,
+run download, and verify resolution terminates and each schema is written exactly once.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cyclic reference `A → B → A`, **When** the developer downloads A, **Then**
+   resolution terminates and both A and B are written exactly once.
+2. **Given** a shared dependency where A and B both reference C at the same version,
+   **When** the developer downloads A and B, **Then** C is written exactly once.
+3. **Given** a diamond with divergent versions where A references B@1 and A→C→B@2, **When**
+   the developer downloads A, **Then** both B@1 and B@2 are written as separate files
+   (identity is subject+version, not subject alone).
+
+---
+
+### Edge Cases
+
+- **Pinned version mismatch**: A referenced schema is requested at a specific (pinned)
+  version that differs from the latest. The exact referenced version MUST be downloaded,
+  not the latest.
+- **Reference fetch failure**: A referenced schema cannot be fetched (deleted, permission
+  denied, registry error). Resolution stops and reports the failing subject; the developer
+  sees a clear error rather than a partial silent result.
+- **Deep reference chains**: A long chain of references (many levels deep) MUST resolve
+  without exhausting resources or failing on depth.
+- **Reference points back to an already-downloaded root**: A referenced subject+version is
+  also one of the explicitly requested roots (same version). It MUST be written exactly
+  once. If the reference pins a *different* version than the root, both versions are
+  written (each is a distinct subject+version identity).
+- **Reference resolution combined with wildcard/incremental/parallel download**: Resolution
+  composes with existing download modes (wildcard subject selection, incremental skip,
+  parallel downloads) without conflict.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect schema references reported by the registry for each
+  downloaded subject.
+- **FR-002**: System MUST transitively download every referenced schema, following
+  references to arbitrary depth.
+- **FR-003**: System MUST download each referenced schema at the exact version recorded in
+  the reference (pinned version), not the latest version.
+- **FR-004**: System MUST prevent infinite loops when the reference graph contains cycles,
+  by tracking visited schemas keyed by **subject + version**.
+- **FR-005**: Within a single download run, System MUST write each resolved schema
+  (identified by subject + version) to disk exactly once, even when it is referenced by
+  multiple subjects or is also an explicitly requested root. Distinct pinned versions of the
+  same subject are written as separate files and MUST NOT be deduplicated against each other.
+  (Cross-run re-writes of identical bytes under incremental download are a known, acceptable
+  redundancy — never a duplicate within one run.)
+- **FR-006**: System MUST provide a configuration setting that enables or disables
+  automatic reference resolution, defaulting to enabled.
+- **FR-007**: When reference resolution is disabled, System MUST download only the
+  explicitly requested subjects, matching the behavior prior to this feature.
+- **FR-008**: System MUST report a clear error identifying the failing subject when a
+  referenced schema cannot be fetched, and MUST NOT silently omit it.
+- **FR-009**: Reference resolution MUST compose with existing download capabilities
+  (wildcard subject selection, incremental download, parallel download).
+- **FR-010**: Root (explicitly requested) schemas MUST appear in deterministic order in
+  the resolution output, ahead of their transitively discovered references.
+
+### Key Entities *(include if feature involves data)*
+
+- **Schema Reference**: A pointer from one schema to another. Has a logical name, the
+  target subject, and the exact target version.
+- **Resolved Schema**: A schema that has been fetched, including its subject, version,
+  content, and the list of references it declares.
+- **Resolution Result**: The complete set of schemas produced by resolving all roots and
+  their transitive references, plus the bookkeeping of which subject+version pairs have
+  already been visited (to guarantee single-write per subject+version and cycle safety).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Downloading a single root subject with a dependency chain of depth N
+  produces all N+1 schema files on disk in one task run, with no manual listing of
+  dependencies.
+- **SC-002**: 100% of referenced schemas are written at their pinned version (zero version
+  drift between the declared reference version and the file written).
+- **SC-003**: Within a single run, resolution of any reference graph — including cyclic,
+  shared-dependency, and divergent-version-diamond graphs — terminates and writes each
+  distinct subject+version exactly once (zero duplicate files, zero hangs, zero
+  silently-dropped versions).
+- **SC-004**: With resolution disabled, download output is byte-for-byte equivalent to the
+  pre-feature behavior for the same inputs (full backward compatibility).
+- **SC-005**: A reference fetch failure surfaces an error naming the failing subject in
+  100% of failure cases (no silent partial success).
+
+## Assumptions
+
+- The registry exposes per-subject/version reference metadata (logical name, target
+  subject, target version) that can be queried for any fetched schema. This matches the
+  Confluent Schema Registry behavior described in issue #31.
+- References are addressed by subject + version; the referenced version is always pinned
+  and available from the reference metadata, so no "latest" lookup is needed for
+  referenced schemas.
+- Auto-resolution enabled-by-default is the desired behavior; existing users who download
+  schemas with references will now also receive the referenced schemas. This is treated as
+  an additive enhancement, with the opt-out setting available for the prior behavior.
+- Fail-fast on the first reference fetch error is the desired default. Partial/accumulated
+  results (continue past failures) are out of scope for this feature.
+- Referenced schemas are written to disk using the same file layout and naming convention
+  as directly downloaded subjects (no separate directory or naming scheme for references).

--- a/specs/007-resolve-schema-references/tasks.md
+++ b/specs/007-resolve-schema-references/tasks.md
@@ -1,0 +1,134 @@
+---
+description: "Task list for feature 007 — auto-download schema references"
+---
+
+# Tasks: Auto-Download Schema References
+
+**Input**: Design documents from `specs/007-resolve-schema-references/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/](contracts/)
+
+**Tests**: INCLUDED — Constitution III (Test-First) mandates tests before implementation for this project.
+
+**Organization**: Grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (maps to spec.md user stories)
+- Every task lists an exact file path
+
+## Path Conventions
+
+Single-project sbt plugin. Production: `src/main/scala/org/galaxio/avro/`. Unit tests:
+`src/test/scala/org/galaxio/avro/`. Integration: `it/src/test/scala/org/galaxio/avro/`.
+Scripted e2e: `src/sbt-test/schema-registry/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Branch and baseline.
+
+- [x] T001 Create feature branch `007-resolve-schema-references` off `main` and verify baseline is green: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared value type every story depends on.
+
+**⚠️ CRITICAL**: Must complete before any user story.
+
+- [x] T002 Add `ResolvedSchema(subject: String, version: Int, references: List[SchemaReference])` case class in new file `src/main/scala/org/galaxio/avro/ReferenceResolver.scala` (reuses existing `SchemaReference`; see [data-model.md](data-model.md))
+
+**Checkpoint**: `ResolvedSchema` compiles — story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Transitive reference download (Priority: P1) 🎯 MVP
+
+**Goal**: Downloading a root schema auto-downloads its referenced schemas transitively, at pinned versions, in one task run.
+
+**Independent Test**: Register a root schema referencing a second schema; run `Compile / schemaRegistryDownload` for the root only; verify both files land on disk (quickstart scenario 2/3).
+
+### Tests (write first)
+
+- [x] T003 [P] [US1] Create `src/test/scala/org/galaxio/avro/ReferenceResolverSpec.scala` (`AnyFlatSpec with Matchers`, Map-based stub `fetch`) covering RR-1 (no refs → single entry), RR-2 (transitive `A→B→C`, BFS roots-first order), RR-8 (latest root also referenced at its resolved version → emitted once), **RR-3 (cycle `A↔B` terminates, each once, no SOE — guards MVP against hangs)**, and **RR-6 (fail-fast: first `Left` short-circuits)**. RR-3/RR-6 are pulled forward into US1 because cycle-safety and fail-fast are intrinsic to MVP correctness and must gate the T004 impl (Constitution III). See [contracts/reference-resolver.md](contracts/reference-resolver.md)
+
+### Implementation
+
+- [x] T004 [US1] Implement pure `ReferenceResolver.resolve(roots, fetch): Either[DownloadError, List[RegistrySubject]]` in `src/main/scala/org/galaxio/avro/ReferenceResolver.scala` — `@tailrec` BFS over immutable `Queue`, two-level dedup (enqueue key `(subject, Option[Int])`, visited key resolved `(subject, Int)`), roots-first output of `RegistrySubject.Pinned`, fail-fast on first `Left` (reuse `DownloadError.SchemaFetchFailed`). Make T003 pass
+- [x] T005 [US1] Declare `schemaRegistryResolveReferences = settingKey[Boolean]("Auto-download schemas referenced by downloaded schemas (transitive)")` in `autoImport` and default `:= true` in `defaultSettings`, in `src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala` (see [contracts/plugin-setting.md](contracts/plugin-setting.md))
+- [x] T006 [US1] In `src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala` `Compile / schemaRegistryDownload`: build the `fetch` closure over the shared `client` (`getLatestSchemaMetadata` for `None` / `getByVersion(name, v, false)` for `Some`; `Option(meta.getReferences).map(_.asScala.toList).getOrElse(Nil)`; unbox `getVersion.intValue`), and insert the gated stage `val expanded = if (resolveReferences) ReferenceResolver.resolve(roots, fetch) else Right(roots)` **between** `SubjectResolver.resolve` and `IncrementalResolver.plan`; thread `expanded` into the existing incremental + parallel stages
+
+### Validation tests
+
+- [x] T007 [P] [US1] Create `it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala` (`AnyFlatSpec` + Testcontainers Kafka + Schema Registry): register base + dependent-with-`SchemaReference`, run resolve+download for the root, assert **both** `<base>-1.avsc` and `<dependent>-1.avsc` exist with correct content (PS-1); add a missing-reference case asserting `SchemaFetchFailed` naming the subject (PS-4); add a **composition** case proving FR-009 — referenced subject already current in the manifest is skipped by incremental (PS-5), and the expanded list downloads under parallelism > 1 (PS-6)
+- [x] T008 [P] [US1] Create scripted test `src/sbt-test/schema-registry/resolve-references/` (`build.sbt`, `test`, `project/plugins.sbt`) following the `register-references` fixture: register base + dependent-with-reference, run `Compile / schemaRegistryDownload`, assert both files via `$ exists` / `$ must-mirror` (PS-1). Select the dependent root via `schemaRegistrySubjectPatterns` (a regex), not an exact subject, so the test also proves resolution composes with **wildcard expansion** (FR-009)
+
+**Checkpoint**: MVP — transitive download works end-to-end (default on).
+
+---
+
+## Phase 4: User Story 2 - Opt-out of reference resolution (Priority: P2)
+
+**Goal**: Setting `schemaRegistryResolveReferences := false` downloads only requested subjects; behavior identical to pre-feature.
+
+**Independent Test**: With the setting off, download a subject that has references; verify only the requested file appears (quickstart scenario 4 / SC-004).
+
+> The gate is implemented in T006. This story verifies the off-path and backward compatibility.
+
+- [x] T009 [US2] Add opt-out assertion to `src/sbt-test/schema-registry/resolve-references/test`: a step with `> set schemaRegistryResolveReferences := false`, re-run download, assert the referenced file is **absent** and the root file present (PS-2)
+- [x] T010 [P] [US2] Verify backward compatibility: confirm existing scripted `src/sbt-test/schema-registry/download-success/` stays green and a no-references subject yields byte-identical output to pre-feature (SC-004 / acceptance 1.3); add a `must-mirror` golden-file check if not already present
+
+**Checkpoint**: Opt-out and backward compatibility proven.
+
+---
+
+## Phase 5: User Story 3 - Safe handling of cyclic and shared references (Priority: P3)
+
+**Goal**: Cyclic, shared-dependency, and divergent-version reference graphs resolve without hangs or duplicate/dropped schemas.
+
+**Independent Test**: Pure-logic graphs (cycle, shared dep, divergent diamond) resolve to the expected deduped, terminating result — best tested as units against `ReferenceResolver` (quickstart scenario 1).
+
+- [x] T011 [US3] Extend `src/test/scala/org/galaxio/avro/ReferenceResolverSpec.scala` with RR-4 (shared dep `D` once), RR-5 (divergent diamond `A→B@1` + `A→C→B@2` keeps **both** `Pinned(B,1)` and `Pinned(B,2)`), RR-7 (deep chain depth ≥10k no `StackOverflow`), RR-9 (counter-wrapped stub proves cycle/shared dedup prevents refetch). (RR-3 cycle and RR-6 fail-fast moved to T003 in US1.) If any reveals an impl gap, fix `ReferenceResolver.resolve` (T004)
+
+**Checkpoint**: Robustness guarantees (FR-004/FR-005/SC-003) verified.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [x] T012 [P] Document `schemaRegistryResolveReferences` (purpose, default `true`, opt-out) and transitive/pinned/cycle behavior in `README.md` and `AGENTS.md`; note the known limitation — subject-keyed `VersionManifest` may redundantly re-write a divergent-version schema on later runs (flagged follow-up, never incorrect; see [research.md](research.md) Decision 4)
+- [x] T013 [P] Run `sbt scalafmtAll scalafmtSbt` and confirm clean compile under `-Xfatal-warnings` (Constitution V); explicitly unbox Confluent `getVersion` to avoid warnings
+- [x] T014 Run full gate from [quickstart.md](quickstart.md): `sbt scalafmtCheckAll scalafmtSbtCheck compile test`, then `sbt it/test` and `sbt scripted` (Docker)
+
+---
+
+## Dependencies & Execution Order
+
+```
+Setup (T001)
+   └─> Foundational (T002)
+          └─> US1 / P1  (T003 → T004 → T005 → T006 → {T007, T008})   ← MVP
+                 ├─> US2 / P2  (T009 → T010)        depends on T006 gate
+                 └─> US3 / P3  (T011)               depends on T004 resolver
+                        └─> Polish (T012, T013 → T014)
+```
+
+- **US2 and US3 are independent of each other** — both depend only on US1, can proceed in either order or concurrently (different files).
+- **Within US1**: T003 (test) before T004 (impl); T004 before T005/T006; T007 and T008 after T006.
+- **Same-file constraints**: T002 and T004 edit `ReferenceResolver.scala` (sequential); T005 and T006 edit `SchemaDownloaderPlugin.scala` (sequential); T003 and T011 edit `ReferenceResolverSpec.scala` (T011 after T003).
+
+## Parallel Execution Examples
+
+- **US1 validation**: after T006, run T007 (integration spec) and T008 (scripted test) in parallel — different files.
+- **Polish**: T012 (docs) and T013 (format) in parallel — different files; T014 (full gate) after both.
+- **Across stories**: once US1 lands, a second contributor can take US2 (scripted/regression) while another takes US3 (unit safety suite).
+
+## Implementation Strategy
+
+- **MVP = US1 (Phase 1–3)**: delivers the entire feature value — transitive, pinned, default-on download. Cycle safety is intrinsic to the T004 resolver (two-level dedup), so the MVP is already correct on cyclic graphs; US3 *proves* it.
+- **Incremental**: ship US1, then US2 (opt-out/back-compat verification), then US3 (robustness test suite), then polish.
+- **Test-first throughout**: T003 before T004; T011 may drive fixes back into T004.

--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -5,6 +5,7 @@ import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import java.util.{Collections, HashMap => JHashMap}
+import scala.collection.JavaConverters._
 import scala.util.Try
 
 final class Downloader private[avro] (
@@ -71,6 +72,28 @@ final class Downloader private[avro] (
 
 object Downloader {
   val defaultCacheSize = 200
+
+  /** Build the `fetch` function [[ReferenceResolver]] needs, backed by a registry client.
+    *
+    * Reads a schema's metadata (`getSchemaMetadata` for a pinned version, `getLatestSchemaMetadata` for latest) and maps its
+    * references to the domain [[SchemaReference]]. Confluent's `getReferences` may be null and its `getVersion` is a boxed
+    * `Integer`, both handled here. Shared by the download task and integration tests so they exercise the same mapping.
+    */
+  private[avro] def referenceFetch(
+      client: SchemaRegistryClient,
+  ): (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
+    (subject, version) =>
+      Try {
+        val meta = version match {
+          case Some(v) => client.getSchemaMetadata(subject, v)
+          case None    => client.getLatestSchemaMetadata(subject)
+        }
+        val refs = Option(meta.getReferences)
+          .map(_.asScala.toList)
+          .getOrElse(Nil)
+          .map(r => SchemaReference(r.getName, r.getSubject, r.getVersion.intValue))
+        ResolvedSchema(subject, meta.getVersion: Int, refs)
+      }.toEither.left.map(DownloadError.SchemaFetchFailed(subject, _))
 
   private[avro] def buildConfig(
       auth: Option[SchemaRegistryAuth],

--- a/src/main/scala/org/galaxio/avro/ReferenceResolver.scala
+++ b/src/main/scala/org/galaxio/avro/ReferenceResolver.scala
@@ -1,0 +1,86 @@
+package org.galaxio.avro
+
+import scala.annotation.tailrec
+import scala.collection.immutable.Queue
+
+/** A schema fetched during reference resolution.
+  *
+  * Carries only what the graph walk needs: its concrete (resolved) version and the references it declares. Bodies are written
+  * later by [[Downloader]].
+  */
+final case class ResolvedSchema(
+    subject: String,
+    version: Int,
+    references: List[SchemaReference],
+)
+
+/** Pure, stack-safe transitive resolver for schema references.
+  *
+  * Given root subjects and an injected `fetch`, walks the reference graph breadth-first and returns every reachable schema as a
+  * pinned subject (roots first, then transitive refs).
+  *
+  * Identity is `(subject, version)` (spec 007 clarification): the walk is cycle-safe and keeps divergent versions of the same
+  * subject. The resolver performs no IO — `fetch` is the only effect, so it is fully testable with a `Map`-based stub.
+  */
+object ReferenceResolver {
+
+  /** @param roots
+    *   requested subjects (Latest or Pinned)
+    * @param fetch
+    *   `(subject, Some(version)=pinned | None=latest) => resolved schema`
+    * @return
+    *   roots-first, deduped list of `RegistrySubject.Pinned`, or the first fetch error
+    */
+  def resolve(
+      roots: List[RegistrySubject],
+      fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema],
+  ): Either[DownloadError, List[RegistrySubject]] = {
+
+    @tailrec
+    def loop(
+        queue: Queue[(String, Option[Int])],
+        enqueued: Set[(String, Option[Int])],
+        visited: Set[(String, Int)],
+        acc: Vector[RegistrySubject],
+    ): Either[DownloadError, List[RegistrySubject]] =
+      queue.dequeueOption match {
+        case None                             => Right(acc.toList)
+        case Some(((subject, version), rest)) =>
+          fetch(subject, version) match {
+            case Left(err)       => Left(err) // fail-fast (FR-008)
+            case Right(resolved) =>
+              val resolvedKey = (resolved.subject, resolved.version)
+              if (visited.contains(resolvedKey)) {
+                // shared dependency or cycle already materialised — skip
+                loop(rest, enqueued, visited, acc)
+              } else {
+                // Skip a child if it is already queued, or if its pinned version is already
+                // resolved (prevents cyclic back-edges from refetching). Divergent versions
+                // of the same subject survive because their pinned versions differ.
+                val newChildren: List[(String, Option[Int])] =
+                  resolved.references
+                    .map(r => (r.subject, Some(r.version)))
+                    .filterNot { case (s, v) =>
+                      enqueued.contains((s, v)) || v.exists(ver => visited.contains((s, ver)))
+                    }
+                loop(
+                  newChildren.foldLeft(rest)((q, c) => q.enqueue(c)),
+                  enqueued ++ newChildren,
+                  visited + resolvedKey,
+                  acc :+ RegistrySubject.Pinned(resolved.subject, resolved.version),
+                )
+              }
+          }
+      }
+
+    val requested            = roots.map {
+      case RegistrySubject.Pinned(name, v) => (name, Some(v))
+      case RegistrySubject.Latest(name)    => (name, None)
+    }
+    val (seedQueue, seedSet) =
+      requested.foldLeft((Queue.empty[(String, Option[Int])], Set.empty[(String, Option[Int])])) { case ((q, seen), elem) =>
+        if (seen.contains(elem)) (q, seen) else (q.enqueue(elem), seen + elem)
+      }
+    loop(seedQueue, seedSet, Set.empty, Vector.empty)
+  }
+}

--- a/src/main/scala/org/galaxio/avro/ReferenceResolver.scala
+++ b/src/main/scala/org/galaxio/avro/ReferenceResolver.scala
@@ -27,7 +27,9 @@ object ReferenceResolver {
   /** @param roots
     *   requested subjects (Latest or Pinned)
     * @param fetch
-    *   `(subject, Some(version)=pinned | None=latest) => resolved schema`
+    *   `(subject, Some(version)=pinned | None=latest) => resolved schema`. `fetch` MUST return a `ResolvedSchema` whose
+    *   `subject` equals the requested subject — the dedup/visited keys and the emitted `Pinned` entries are derived from
+    *   `resolved.subject`.
     * @return
     *   roots-first, deduped list of `RegistrySubject.Pinned`, or the first fetch error
     */
@@ -55,11 +57,14 @@ object ReferenceResolver {
                 loop(rest, enqueued, visited, acc)
               } else {
                 // Skip a child if it is already queued, or if its pinned version is already
-                // resolved (prevents cyclic back-edges from refetching). Divergent versions
-                // of the same subject survive because their pinned versions differ.
+                // resolved (prevents cyclic back-edges from refetching). `distinct` collapses a
+                // schema that declares the same (subject, version) reference more than once, so it
+                // is not enqueued (and refetched) twice. Divergent versions of the same subject
+                // survive because their pinned versions differ.
                 val newChildren: List[(String, Option[Int])] =
                   resolved.references
                     .map(r => (r.subject, Some(r.version)))
+                    .distinct
                     .filterNot { case (s, v) =>
                       enqueued.contains((s, v)) || v.exists(ver => visited.contains((s, ver)))
                     }

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -6,6 +6,7 @@ import Keys.*
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path => JPath}
+import scala.collection.JavaConverters._
 import scala.util.{Try, Using}
 
 object SchemaDownloaderPlugin extends AutoPlugin {
@@ -30,19 +31,22 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       settingKey[Int]("Number of concurrent schema downloads (1 = sequential)")
     val schemaRegistryRetries           =
       settingKey[Int]("Maximum retry attempts for transient download failures (0 = no retry)")
+    val schemaRegistryResolveReferences =
+      settingKey[Boolean]("Auto-download schemas referenced by downloaded schemas (transitive)")
 
     lazy val defaultSettings: Seq[Setting[?]] = Seq(
-      schemaRegistryUrl             := "http://localhost:8081",
-      schemaRegistryTargetFolder    := sourceDirectory.value / "main" / "avro",
-      schemaRegistrySubjects        := Seq(),
-      schemaRegistrySubjectPatterns := Seq(),
-      schemaRegistryRegistrations   := Seq(),
-      schemaRegistryCacheSize       := Downloader.defaultCacheSize,
-      schemaRegistryAuth            := None,
-      schemaRegistryProperties      := Map.empty,
-      schemaRegistryIncremental     := true,
-      schemaRegistryParallelism     := 4,
-      schemaRegistryRetries         := 3,
+      schemaRegistryUrl               := "http://localhost:8081",
+      schemaRegistryTargetFolder      := sourceDirectory.value / "main" / "avro",
+      schemaRegistrySubjects          := Seq(),
+      schemaRegistrySubjectPatterns   := Seq(),
+      schemaRegistryRegistrations     := Seq(),
+      schemaRegistryCacheSize         := Downloader.defaultCacheSize,
+      schemaRegistryAuth              := None,
+      schemaRegistryProperties        := Map.empty,
+      schemaRegistryIncremental       := true,
+      schemaRegistryParallelism       := 4,
+      schemaRegistryRetries           := 3,
+      schemaRegistryResolveReferences := true,
     )
   }
 
@@ -82,6 +86,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       val incremental  = schemaRegistryIncremental.value
       val parallelism  = schemaRegistryParallelism.value
       val retries      = schemaRegistryRetries.value
+      val resolveRefs  = schemaRegistryResolveReferences.value
       val manifestFile =
         streams.value.cacheDirectory.toPath.resolve(".schema-versions.json")
 
@@ -92,6 +97,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       logger.debug(s"schemaRegistryIncremental: $incremental")
       logger.debug(s"schemaRegistryParallelism: $parallelism")
       logger.debug(s"schemaRegistryRetries: $retries")
+      logger.debug(s"schemaRegistryResolveReferences: $resolveRefs")
 
       if (parallelism < 1 || parallelism > ParallelDownloader.MaxParallelism)
         sys.error(DownloadError.InvalidParallelism(parallelism).message)
@@ -126,19 +132,47 @@ object SchemaDownloaderPlugin extends AutoPlugin {
             }
           }
 
+          val expandedSubjects: List[RegistrySubject] =
+            if (!resolveRefs) resolvedSubjects.toList
+            else {
+              val fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
+                (subject, version) =>
+                  Try {
+                    val meta = version match {
+                      case Some(v) => client.getSchemaMetadata(subject, v)
+                      case None    => client.getLatestSchemaMetadata(subject)
+                    }
+                    val refs = Option(meta.getReferences)
+                      .map(_.asScala.toList)
+                      .getOrElse(Nil)
+                      .map(r => SchemaReference(r.getName, r.getSubject, r.getVersion.intValue))
+                    ResolvedSchema(subject, meta.getVersion: Int, refs)
+                  }.toEither.left.map(DownloadError.SchemaFetchFailed(subject, _))
+
+              ReferenceResolver.resolve(resolvedSubjects.toList, fetch) match {
+                case Left(err)       =>
+                  err.cause.foreach(logger.trace(_))
+                  sys.error(err.message)
+                case Right(expanded) =>
+                  val extra = expanded.size - resolvedSubjects.size
+                  if (extra > 0) logger.info(s"Resolved $extra referenced schema(s)")
+                  expanded
+              }
+            }
+
           val manifest = loadManifest(manifestFile, incremental, logger)
 
           val decisions =
             if (incremental)
               IncrementalResolver.plan(
                 manifest,
-                resolvedSubjects.toList,
+                expandedSubjects,
                 s =>
                   Try(client.getLatestSchemaMetadata(s).getVersion: Int).toEither.left
                     .map(DownloadError.SchemaFetchFailed(s, _)),
               )
             else
-              resolvedSubjects.toList.map(s => DownloadDecision.Download(s, "incremental disabled"))
+              expandedSubjects.map(s => DownloadDecision.Download(s, "incremental disabled"))
 
           val (skips, downloads) = decisions.partition {
             case _: DownloadDecision.Skip => true

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -6,7 +6,6 @@ import Keys.*
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path => JPath}
-import scala.collection.JavaConverters._
 import scala.util.{Try, Using}
 
 object SchemaDownloaderPlugin extends AutoPlugin {
@@ -135,19 +134,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
           val expandedSubjects: List[RegistrySubject] =
             if (!resolveRefs) resolvedSubjects.toList
             else {
-              val fetch: (String, Option[Int]) => Either[DownloadError, ResolvedSchema] =
-                (subject, version) =>
-                  Try {
-                    val meta = version match {
-                      case Some(v) => client.getSchemaMetadata(subject, v)
-                      case None    => client.getLatestSchemaMetadata(subject)
-                    }
-                    val refs = Option(meta.getReferences)
-                      .map(_.asScala.toList)
-                      .getOrElse(Nil)
-                      .map(r => SchemaReference(r.getName, r.getSubject, r.getVersion.intValue))
-                    ResolvedSchema(subject, meta.getVersion: Int, refs)
-                  }.toEither.left.map(DownloadError.SchemaFetchFailed(subject, _))
+              val fetch = Downloader.referenceFetch(client)
 
               ReferenceResolver.resolve(resolvedSubjects.toList, fetch) match {
                 case Left(err)       =>

--- a/src/sbt-test/schema-registry/resolve-references/build.sbt
+++ b/src/sbt-test/schema-registry/resolve-references/build.sbt
@@ -1,0 +1,22 @@
+import org.galaxio.avro.{RegistryRegistration, SchemaReference}
+
+// Register a base schema and a dependent schema that references it, then download ONLY the
+// dependent (selected via a regex pattern, not an exact subject). Reference resolution must
+// transitively pull in the base schema — proving FR-009 composes with wildcard expansion.
+// Incremental is disabled so each download re-fetches deterministically (the opt-out step
+// deletes files and re-downloads).
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion              := "2.12.21",
+    schemaRegistryUrl         := RegistryFixture.url,
+    schemaRegistryIncremental := false,
+    schemaRegistryRegistrations := Seq(
+      RegistryRegistration("it.e2e.Base", baseDirectory.value / "src/main/avro/Base.avsc"),
+      RegistryRegistration(
+        "it.e2e.Dependent",
+        baseDirectory.value / "src/main/avro/Dependent.avsc",
+        references = List(SchemaReference("Base", "it.e2e.Base", 1)),
+      ),
+    ),
+    schemaRegistrySubjectPatterns := Seq("it\\.e2e\\.Dependent"),
+  )

--- a/src/sbt-test/schema-registry/resolve-references/project/RegistryFixture.scala
+++ b/src/sbt-test/schema-registry/resolve-references/project/RegistryFixture.scala
@@ -1,0 +1,44 @@
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import org.apache.avro.Schema
+import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+object RegistryFixture {
+  val subjectA    = "it.e2e.Order"
+  val subject     = subjectA
+  val schemaJsonA =
+    """{"type":"record","name":"Order","namespace":"it.e2e","fields":[{"name":"id","type":"long"}]}"""
+
+  val subjectB    = "it.e2e.User"
+  val schemaJsonB =
+    """{"type":"record","name":"User","namespace":"it.e2e","fields":[{"name":"name","type":"string"}]}"""
+
+  private val confluentTag = "7.5.0"
+
+  lazy val url: String = {
+    val network = Network.newNetwork()
+
+    val kafka = new ConfluentKafkaContainer(DockerImageName.parse(s"confluentinc/cp-kafka:$confluentTag"))
+    kafka.withListener("kafka:19092")
+    kafka.withNetwork(network)
+    kafka.start()
+
+    val sr = new JGenericContainer(DockerImageName.parse(s"confluentinc/cp-schema-registry:$confluentTag"))
+    sr.withNetwork(network)
+    sr.withExposedPorts(8081)
+    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+    sr.start()
+
+    val u      = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
+    val client = new CachedSchemaRegistryClient(u, 10)
+    client.register(subjectA, new AvroSchema(new Schema.Parser().parse(schemaJsonA)))
+    client.register(subjectB, new AvroSchema(new Schema.Parser().parse(schemaJsonB)))
+    client.close()
+    u
+  }
+}

--- a/src/sbt-test/schema-registry/resolve-references/project/plugins.sbt
+++ b/src/sbt-test/schema-registry/resolve-references/project/plugins.sbt
@@ -1,0 +1,8 @@
+resolvers ++= Seq("Confluent" at "https://packages.confluent.io/maven/")
+
+libraryDependencies += "org.testcontainers" % "kafka" % "1.21.3"
+
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("org.galaxio" % "sbt-schema-registry-plugin" % v)
+  case None    => sys.error("plugin.version system property not set (provided by scriptedLaunchOpts)")
+}

--- a/src/sbt-test/schema-registry/resolve-references/src/main/avro/Base.avsc
+++ b/src/sbt-test/schema-registry/resolve-references/src/main/avro/Base.avsc
@@ -1,0 +1,1 @@
+{"type":"record","name":"Base","namespace":"it.e2e","fields":[{"name":"id","type":"long"}]}

--- a/src/sbt-test/schema-registry/resolve-references/src/main/avro/Dependent.avsc
+++ b/src/sbt-test/schema-registry/resolve-references/src/main/avro/Dependent.avsc
@@ -1,0 +1,1 @@
+{"type":"record","name":"Dependent","namespace":"it.e2e","fields":[{"name":"base_id","type":"long"},{"name":"value","type":"string"}]}

--- a/src/sbt-test/schema-registry/resolve-references/test
+++ b/src/sbt-test/schema-registry/resolve-references/test
@@ -1,0 +1,15 @@
+# Register base + dependent (with a reference), then download only the dependent via a
+# wildcard pattern. Reference resolution (default ON) must also fetch the base schema.
+> Compile / schemaRegistryRegister
+> Compile / schemaRegistryDownload
+$ exists src/main/avro/it.e2e.Dependent-1.avsc
+$ exists src/main/avro/it.e2e.Base-1.avsc
+
+# Opt-out: disable reference resolution and re-download — only the dependent is fetched,
+# the referenced base schema must NOT appear.
+$ delete src/main/avro/it.e2e.Dependent-1.avsc
+$ delete src/main/avro/it.e2e.Base-1.avsc
+> set schemaRegistryResolveReferences := false
+> Compile / schemaRegistryDownload
+$ exists src/main/avro/it.e2e.Dependent-1.avsc
+$ absent src/main/avro/it.e2e.Base-1.avsc

--- a/src/test/scala/org/galaxio/avro/ReferenceResolverSpec.scala
+++ b/src/test/scala/org/galaxio/avro/ReferenceResolverSpec.scala
@@ -156,6 +156,20 @@ class ReferenceResolverSpec extends AnyFlatSpec with Matchers {
     counts.values.sum shouldBe 4 // A, B, C, D each exactly once
   }
 
+  // --- A schema declaring the same reference twice is fetched once ---
+
+  it should "fetch a duplicated reference only once" in {
+    val g           = Map(
+      k("A")          -> schema("A", 1, ref("B", 1), ref("B", 1)),
+      k("B", Some(1)) -> schema("B", 1),
+    )
+    val (f, counts) = counting(stub(g))
+    val out         = ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), f).getOrElse(fail())
+
+    out shouldBe List(pinned("A", 1), pinned("B", 1))
+    counts.getOrElse(k("B", Some(1)), 0) shouldBe 1
+  }
+
   // --- Pinned roots pass through their own version ---
 
   it should "resolve a pinned root at its pinned version (RR-2 variant)" in {

--- a/src/test/scala/org/galaxio/avro/ReferenceResolverSpec.scala
+++ b/src/test/scala/org/galaxio/avro/ReferenceResolverSpec.scala
@@ -1,0 +1,169 @@
+package org.galaxio.avro
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable
+
+class ReferenceResolverSpec extends AnyFlatSpec with Matchers {
+
+  private type Key   = (String, Option[Int])
+  private type Fetch = (String, Option[Int]) => Either[DownloadError, ResolvedSchema]
+
+  private def k(s: String, v: Option[Int] = None): Key = (s, v)
+
+  private def ref(subject: String, version: Int): SchemaReference =
+    SchemaReference(subject, subject, version)
+
+  private def schema(subject: String, version: Int, refs: SchemaReference*): ResolvedSchema =
+    ResolvedSchema(subject, version, refs.toList)
+
+  private def stub(graph: Map[Key, ResolvedSchema]): Fetch =
+    (s, v) => graph.get((s, v)).toRight(DownloadError.SchemaFetchFailed(s, new RuntimeException(s"not found: $s@$v")))
+
+  /** Wrap a fetch to record how many times each (subject, requestedVersion) was requested. */
+  private def counting(underlying: Fetch): (Fetch, mutable.Map[Key, Int]) = {
+    val counts         = mutable.Map.empty[Key, Int]
+    val counted: Fetch = (s, v) => {
+      counts.update((s, v), counts.getOrElse((s, v), 0) + 1)
+      underlying(s, v)
+    }
+    (counted, counts)
+  }
+
+  private def pinned(subject: String, version: Int): RegistrySubject =
+    RegistrySubject.Pinned(subject, version)
+
+  // --- RR-0: empty roots ---
+
+  "resolve" should "return an empty list for empty roots" in {
+    ReferenceResolver.resolve(Nil, stub(Map.empty)) shouldBe Right(Nil)
+  }
+
+  // --- RR-1: no references ---
+
+  it should "return a single pinned entry for a root with no references (RR-1)" in {
+    val g = Map(k("A") -> schema("A", 1))
+    ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), stub(g)) shouldBe
+      Right(List(pinned("A", 1)))
+  }
+
+  // --- RR-2: transitive A -> B -> C, BFS roots-first ---
+
+  it should "resolve a transitive chain A->B->C in roots-first order (RR-2)" in {
+    val g = Map(
+      k("A")          -> schema("A", 1, ref("B", 1)),
+      k("B", Some(1)) -> schema("B", 1, ref("C", 1)),
+      k("C", Some(1)) -> schema("C", 1),
+    )
+    ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), stub(g)) shouldBe
+      Right(List(pinned("A", 1), pinned("B", 1), pinned("C", 1)))
+  }
+
+  // --- RR-8: latest root also referenced at its resolved version -> emitted once ---
+
+  it should "emit a subject once when a latest root is also referenced at its resolved version (RR-8)" in {
+    val g   = Map(
+      k("A")          -> schema("A", 1, ref("B", 1)),
+      k("B", Some(1)) -> schema("B", 1, ref("A", 1)),
+      k("A", Some(1)) -> schema("A", 1, ref("B", 1)),
+    )
+    val out = ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), stub(g)).getOrElse(fail())
+    out.count(_ == pinned("A", 1)) shouldBe 1
+    out should contain(pinned("B", 1))
+  }
+
+  // --- RR-3: cycle A<->B terminates, each once, A fetched once, no SOE ---
+
+  it should "terminate on a cycle A<->B with each subject once and A fetched once (RR-3)" in {
+    val g           = Map(
+      k("A")          -> schema("A", 1, ref("B", 1)),
+      k("B", Some(1)) -> schema("B", 1, ref("A", 1)),
+      k("A", Some(1)) -> schema("A", 1, ref("B", 1)),
+    )
+    val (f, counts) = counting(stub(g))
+    val out         = ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), f).getOrElse(fail())
+
+    out.map(_.name) shouldBe List("A", "B")
+    out.distinct shouldBe out
+    counts.getOrElse(k("A"), 0) shouldBe 1
+    counts.getOrElse(k("A", Some(1)), 0) shouldBe 0 // back-edge must not refetch A
+  }
+
+  // --- RR-4: shared dependency D resolved once, BFS order ---
+
+  it should "resolve a shared dependency exactly once in BFS order (RR-4)" in {
+    val g   = Map(
+      k("A")          -> schema("A", 1, ref("B", 1), ref("C", 1)),
+      k("B", Some(1)) -> schema("B", 1, ref("D", 1)),
+      k("C", Some(1)) -> schema("C", 1, ref("D", 1)),
+      k("D", Some(1)) -> schema("D", 1),
+    )
+    val out = ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), stub(g)).getOrElse(fail())
+    out.map(_.name) shouldBe List("A", "B", "C", "D")
+    out.count(_.name == "D") shouldBe 1
+  }
+
+  // --- RR-5: divergent-version diamond keeps both B@1 and B@2 ---
+
+  it should "keep both versions in a divergent-version diamond (RR-5)" in {
+    val g   = Map(
+      k("A")          -> schema("A", 1, ref("B", 1), ref("C", 1)),
+      k("B", Some(1)) -> schema("B", 1),
+      k("C", Some(1)) -> schema("C", 1, ref("B", 2)),
+      k("B", Some(2)) -> schema("B", 2),
+    )
+    val out = ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), stub(g)).getOrElse(fail())
+    out.toSet shouldBe Set(pinned("A", 1), pinned("B", 1), pinned("C", 1), pinned("B", 2))
+  }
+
+  // --- RR-7: deep chain is stack-safe ---
+
+  it should "resolve a deep reference chain without StackOverflow (RR-7)" in {
+    val depth = 10000
+    val g     = (0 until depth).map { i =>
+      val key: Key                   = if (i == 0) k("s0") else k(s"s$i", Some(1))
+      val refs: Seq[SchemaReference] = if (i < depth - 1) Seq(ref(s"s${i + 1}", 1)) else Nil
+      key -> ResolvedSchema(s"s$i", 1, refs.toList)
+    }.toMap
+    ReferenceResolver.resolve(List(RegistrySubject.Latest("s0")), stub(g)).map(_.size) shouldBe Right(depth)
+  }
+
+  // --- RR-6: fail-fast on first fetch error ---
+
+  it should "fail fast with the failing subject on a fetch error (RR-6)" in {
+    val g   = Map(k("A") -> schema("A", 1, ref("MISSING", 9)))
+    val out = ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), stub(g))
+    out shouldBe a[Left[_, _]]
+    val err = out.swap.getOrElse(fail())
+    err shouldBe a[DownloadError.SchemaFetchFailed]
+    err.asInstanceOf[DownloadError.SchemaFetchFailed].subject shouldBe "MISSING"
+  }
+
+  // --- RR-9: dedup prevents refetch (count proof) ---
+
+  it should "fetch each subject at most once for a shared-dependency graph (RR-9)" in {
+    val g           = Map(
+      k("A")          -> schema("A", 1, ref("B", 1), ref("C", 1)),
+      k("B", Some(1)) -> schema("B", 1, ref("D", 1)),
+      k("C", Some(1)) -> schema("C", 1, ref("D", 1)),
+      k("D", Some(1)) -> schema("D", 1),
+    )
+    val (f, counts) = counting(stub(g))
+    ReferenceResolver.resolve(List(RegistrySubject.Latest("A")), f).getOrElse(fail())
+
+    counts.getOrElse(k("D", Some(1)), 0) shouldBe 1
+    counts.values.sum shouldBe 4 // A, B, C, D each exactly once
+  }
+
+  // --- Pinned roots pass through their own version ---
+
+  it should "resolve a pinned root at its pinned version (RR-2 variant)" in {
+    val g = Map(
+      k("A", Some(2)) -> schema("A", 2, ref("B", 1)),
+      k("B", Some(1)) -> schema("B", 1),
+    )
+    ReferenceResolver.resolve(List(RegistrySubject.Pinned("A", 2)), stub(g)) shouldBe
+      Right(List(pinned("A", 2), pinned("B", 1)))
+  }
+}


### PR DESCRIPTION
## Summary

Auto-download referenced schemas transitively during schema download. When a schema declares references (e.g., Order → Customer), the plugin now fetches every referenced schema at its pinned version and writes all files in one run.

## What changed

### Core feature
- **ReferenceResolver**: pure, `@tailrec` BFS resolver with two-level dedup:
  - Enqueue key: `(subject, Option[Int])` — prevents re-queuing same work
  - Visited key: resolved `(subject, Int)` — result identity, cycle detection
  - Cycle-safe, stack-safe for deep chains (tested to 10k depth)
  - Roots-first output (BFS order), fail-fast on first fetch error

- **New setting**: `schemaRegistryResolveReferences` (default `true`)
  - Gates the resolve stage between wildcard-expand and incremental-skip
  - Opt-out: `schemaRegistryResolveReferences := false` restores pre-feature behavior

### Reuse (no duplication)
- `SchemaReference`: already had the structure we needed
- `DownloadError.SchemaFetchFailed`: used for fetch errors (fail-fast)
- `RegistrySubject.Pinned`: output all resolved refs as Pinned
- `IncrementalResolver`, `ParallelDownloader`: unchanged, work with expanded list

### Documentation
- README: fixed stale "no incremental caching" blockquote, added Settings rows (4 missing),
  new Download Options section
- AGENTS.md: updated architecture description

## Test plan

- **Unit tests** (11 in ReferenceResolverSpec): transitive A→B→C, cycle A↔B, shared dep,
  divergent diamond A→B@1+B@2 (both kept), deep chain (10k no SOE), fail-fast
  
- **Integration tests** (4 in ReferenceResolutionIntegrationSpec): real Testcontainers
  registry, resolution composition with incremental-skip (PS-5) and parallel downloads
  (PS-6), missing-reference error handling (PS-4)
  
- **Scripted e2e** (resolve-references): wildcard pattern + ref download + opt-out path

- **Backward-compat**: existing no-ref scripted tests (download-success, register-then-download)
  pass, byte-identical output confirms SC-004

## Known limitation (follow-up)

Manifest is subject-keyed (one version per subject). A single run that resolves two
different versions of the same subject will only record the last one, so the other may
be redundantly re-written on later incremental runs (wasteful but never incorrect).
Widening the manifest key to subject+version is a separate feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)