### PR TITLE
feat: add schemaRegistryListSubjects task (#32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@ Use AGENTS.md as the primary repository instruction file for this project.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/007-resolve-schema-references/plan.md
+at specs/008-list-subjects-task/plan.md
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The build will fail if any schema download fails.
 | `schemaRegistryParallelism`       | Number of concurrent schema downloads (1 = sequential)           | `4`                     |
 | `schemaRegistryRetries`           | Maximum retry attempts for transient download failures (0 = none) | `3`                    |
 | `schemaRegistryResolveReferences` | Auto-download referenced schemas transitively                    | `true`                  |
+| `schemaRegistrySubjectFilter`     | Optional case-insensitive substring filter for `schemaRegistryListSubjects` | `None`        |
 
 ## Schema References
 
@@ -169,6 +170,37 @@ Schemas are fetched concurrently with a bounded thread pool. Tune the degree of 
 schemaRegistryParallelism := 8   // 1..32
 schemaRegistryRetries     := 3   // 0..10, 0 = no retry
 ```
+
+## Listing Subjects
+
+Discover what exists in the registry without reaching for `curl` or a separate UI. The
+`schemaRegistryListSubjects` task fetches every subject — sorted, with its version range and
+compatibility level — and prints it to the sbt log. It reuses the same connection settings
+(`schemaRegistryUrl`, `schemaRegistryAuth`, `schemaRegistryProperties`) as the other tasks.
+
+```bash
+sbt schemaRegistryListSubjects
+# [info] Found 42 subject(s):
+# [info]   user-value                                (versions: 1..5, compat: BACKWARD)
+# [info]   order-value                               (versions: 1..3, compat: (default))
+```
+
+A subject with no subject-level compatibility override is shown as `(default)` (the global default
+applies). Compatibility is advisory and best-effort: any failed compatibility lookup (including a
+permissions error) is also shown as `(default)` and never fails the task — only the subject list and
+per-subject versions are hard requirements. Narrow the listing with `schemaRegistrySubjectFilter` — a case-insensitive substring match
+on the subject name (an unset or empty filter lists everything):
+
+```bash
+sbt 'set schemaRegistrySubjectFilter := Some("order")' schemaRegistryListSubjects
+# [info] Found 1 subject(s):
+# [info]   order-value                               (versions: 1..3, compat: FULL)
+```
+
+Per-subject metadata (versions + compatibility) is fetched concurrently using the same
+`schemaRegistryParallelism` budget as downloads (`1` = sequential, up to `32`), so large registries
+list quickly. The task is read-only and never registers, deletes, or mutates anything. It fails with
+a clear message if the registry is unreachable, or if a listed subject's versions cannot be fetched.
 
 ## Schema Registration (Push)
 

--- a/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
@@ -1,0 +1,111 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import org.apache.avro.Schema
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+import scala.util.Try
+
+class SubjectExplorerIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private var network: Network                           = _
+  private var kafka: ConfluentKafkaContainer             = _
+  private var sr: JGenericContainer[_]                   = _
+  private var registryUrl: String                        = _
+  private var registryClient: CachedSchemaRegistryClient = _
+
+  private val orderSubject = "it.e2e.Order-value"
+  private val userSubject  = "it.e2e.User-value"
+
+  override def beforeAll(): Unit = {
+    network = Network.newNetwork()
+
+    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+    kafka.withListener("kafka:19092")
+    kafka.withNetwork(network)
+    kafka.start()
+
+    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
+    sr.withNetwork(network)
+    sr.withExposedPorts(8081)
+    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+    sr.start()
+
+    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
+    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
+
+    registerTestSubjects()
+  }
+
+  override def afterAll(): Unit = {
+    Option(sr).foreach(c => Try(c.stop()))
+    Option(kafka).foreach(c => Try(c.stop()))
+    Option(network).foreach(c => Try(c.close()))
+  }
+
+  private def avro(json: String): AvroSchema =
+    new AvroSchema(new Schema.Parser().parse(json))
+
+  private def registerTestSubjects(): Unit = {
+    // Order: two backward-compatible versions (adding a field with a default is backward compatible).
+    registryClient.register(
+      orderSubject,
+      avro("""{"type":"record","name":"Order","namespace":"it.e2e","fields":[{"name":"id","type":"long"}]}"""),
+    )
+    registryClient.register(
+      orderSubject,
+      avro(
+        """{"type":"record","name":"Order","namespace":"it.e2e","fields":[{"name":"id","type":"long"},{"name":"note","type":"string","default":""}]}""",
+      ),
+    )
+    // User: single version, no subject-level compatibility override.
+    registryClient.register(
+      userSubject,
+      avro("""{"type":"record","name":"User","namespace":"it.e2e","fields":[{"name":"name","type":"string"}]}"""),
+    )
+    // Subject-level compatibility override on Order only.
+    registryClient.updateCompatibility(orderSubject, "BACKWARD")
+  }
+
+  "SubjectExplorer.listAll (integration)" should "list all subjects sorted with correct version ranges" in {
+    val result = SubjectExplorer.listAll(registryClient, None)
+
+    result shouldBe a[Right[_, _]]
+    val listing = result.right.get
+    listing.subjects.map(_.name) shouldBe List(orderSubject, userSubject)
+
+    val order = listing.subjects.find(_.name == orderSubject).get
+    order.versions shouldBe List(1, 2)
+    order.versionRange shouldBe "1..2"
+
+    val user = listing.subjects.find(_.name == userSubject).get
+    user.versionRange shouldBe "1"
+  }
+
+  it should "surface a subject-level compatibility override and report None for subjects without one" in {
+    val listing = SubjectExplorer.listAll(registryClient, None).right.get
+    listing.subjects.find(_.name == orderSubject).get.compatibility shouldBe Some("BACKWARD")
+    listing.subjects.find(_.name == userSubject).get.compatibility shouldBe None
+  }
+
+  it should "produce the same result with parallelism > 1 as sequential" in {
+    val seq = SubjectExplorer.listAll(registryClient, None).right.get
+    val par = SubjectExplorer.listAll(registryClient, None, parallelism = 4).right.get
+    par.subjects shouldBe seq.subjects
+  }
+
+  it should "narrow the listing with a case-insensitive filter" in {
+    val listing = SubjectExplorer.listAll(registryClient, Some("order")).right.get
+    listing.subjects.map(_.name) shouldBe List(orderSubject)
+    listing.size shouldBe 1
+  }
+}

--- a/specs/008-list-subjects-task/checklists/requirements.md
+++ b/specs/008-list-subjects-task/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: List Subjects Task
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Entity names (`SubjectInfo`, `SubjectListing`, `RegistryError`) are retained from issue #32 as domain vocabulary, not implementation prescription — they describe *what* is modeled, not *how*.
+- Two scope decisions flagged as open questions in issue #32 are now resolved via `/speckit-clarify` (Session 2026-06-20) and recorded in the spec's Clarifications + Assumptions: (1) filter = **case-insensitive substring**, (2) **fail-fast** on per-subject version-fetch errors (compatibility lookup stays best-effort).

--- a/specs/008-list-subjects-task/contracts/plugin-api.md
+++ b/specs/008-list-subjects-task/contracts/plugin-api.md
@@ -1,0 +1,119 @@
+# Contract: List Subjects Task — Public sbt Surface & Core API
+
+**Feature**: 008-list-subjects-task | **Date**: 2026-06-20
+
+This is a published sbt plugin. The "contract" is (a) the sbt keys users configure and invoke, and (b) the internal core API the task delegates to. All additions are backward-compatible (Constitution I): no existing key or behavior changes.
+
+---
+
+## 1. sbt task (user-facing command)
+
+```
+schemaRegistryListSubjects   # taskKey[Unit]
+```
+
+- Invoked as `sbt schemaRegistryListSubjects`.
+- Connects using the build's existing registry settings (no new connection config).
+- Prints a sorted, human-readable listing to the sbt log at `info` level.
+- **Success contract**: exits successfully; logs the total count then one line per subject.
+- **Failure contract**: fails the task (non-zero) with a single actionable message when the subject list cannot be fetched, or when a listed subject's versions cannot be fetched (fail-fast).
+
+### Output contract (info log)
+
+```
+Found <N> subject(s):
+  <name padded>  (versions: <range>, compat: <LEVEL|(default)>)
+  ...
+```
+
+- `<N>` = count after filtering.
+- `<range>` = `none` | `<v>` | `<first>..<last>`.
+- `compat` = subject-level level, or `(default)` when none/unreadable.
+- Zero subjects ⇒ `Found 0 subjects:` and no rows (still success).
+
+Exact column widths/format are presentation detail (not contract-frozen); the **fields shown** (name, version range, compatibility) are the contract.
+
+---
+
+## 2. sbt setting (user-facing config)
+
+```
+schemaRegistrySubjectFilter   # settingKey[Option[String]], default None
+```
+
+- `None` (default) ⇒ list all subjects.
+- `Some(text)` ⇒ list only subjects whose name **contains** `text`, case-insensitive.
+- `Some("")` ⇒ behaves as `None` (matches all).
+
+Usage:
+
+```scala
+// list all
+sbt schemaRegistryListSubjects
+
+// filter
+sbt 'set schemaRegistrySubjectFilter := Some("order")' schemaRegistryListSubjects
+```
+
+### Reused settings (read, never modified)
+
+`schemaRegistryUrl`, `schemaRegistryCacheSize`, `schemaRegistryAuth`, `schemaRegistryProperties` — same client construction as the download/register/compatibility tasks.
+
+---
+
+## 3. Core API (internal, `org.galaxio.avro`)
+
+```scala
+final case class SubjectInfo(
+  name: String,
+  versions: List[Int],
+  compatibility: Option[String],
+) {
+  def latestVersion: Option[Int]
+  def versionRange: String     // "none" | "<v>" | "<first>..<last>"
+}
+
+final case class SubjectListing(subjects: List[SubjectInfo]) {
+  def size: Int
+  def matching(filter: String): SubjectListing   // case-insensitive substring on name
+}
+
+object SubjectExplorer {
+  def listAll(
+    client: SchemaRegistryClient,
+    filter: Option[String],
+    parallelism: Int = 1,   // concurrent per-subject fetches; reuses schemaRegistryParallelism
+  ): Either[DownloadError, SubjectListing]
+}
+```
+
+### `SubjectExplorer.listAll` contract
+
+| Aspect | Guarantee |
+|---|---|
+| Purity | No logging, no `sys.error`, no file I/O; only reads via the injected `client` |
+| Ordering | Result subjects sorted by `name` ascending; each `versions` ascending |
+| Subject-list failure | `Left(DownloadError.SubjectListFailed(cause))` |
+| Per-subject versions failure | `Left(DownloadError.SubjectVersionsFetchFailed(subject, cause))` — fail-fast, stops at first |
+| Compatibility absent/failed | `compatibility = None` (never an error) |
+| Filtering | `None` ⇒ all; `Some(t)` ⇒ `listing.matching(t)` |
+
+### Error additions (`DownloadError`)
+
+```scala
+final case class SubjectVersionsFetchFailed(subject: String, error: Throwable) extends DownloadError {
+  val message = s"Failed to fetch versions for $subject: ${error.getMessage}"
+  override def cause = Some(error)
+}
+```
+
+`SubjectListFailed` is reused as-is.
+
+---
+
+## 4. Backward-compatibility assertions
+
+- No rename/removal/retype of any existing key.
+- No change to download/register/compatibility task behavior.
+- New keys are additive with safe defaults (`schemaRegistrySubjectFilter := None`).
+- Builds that never call `schemaRegistryListSubjects` are byte-for-byte unaffected.

--- a/specs/008-list-subjects-task/data-model.md
+++ b/specs/008-list-subjects-task/data-model.md
@@ -1,0 +1,106 @@
+# Data Model: List Subjects Task
+
+**Feature**: 008-list-subjects-task | **Date**: 2026-06-20
+
+All types are immutable Scala values in package `org.galaxio.avro`. New types are additive; no existing type changes shape.
+
+---
+
+## SubjectInfo (new)
+
+One discovered subject and its registry metadata.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `String` | subject name, e.g. `order-value` |
+| `versions` | `List[Int]` | registered versions, ascending; never empty for a listed subject (a subject that returns no versions is treated as a fetch failure — see fail-fast) |
+| `compatibility` | `Option[String]` | subject-level compatibility level (e.g. `BACKWARD`); `None` when no override or lookup failed (best-effort) |
+
+**Derived (pure)**:
+- `latestVersion: Option[Int]` = `versions.lastOption`
+- `versionRange: String` = `none` if empty; the single value if one; `"<first>..<last>"` if many (e.g. `1..5`)
+
+**Validation / invariants**:
+- `versions` is sorted ascending (the explorer sorts on read).
+- No formatting/logging logic lives here (FR-009).
+
+---
+
+## SubjectListing (new)
+
+The result of a list operation — a wrapper over many `SubjectInfo`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `subjects` | `List[SubjectInfo]` | sorted by `name` ascending |
+
+**Pure transformation**:
+- `matching(filter: String): SubjectListing` — returns a copy keeping subjects whose `name` **contains** `filter`, case-insensitive (D5). Empty `filter` ⇒ unchanged (all match).
+
+**Derived**:
+- `size: Int` = `subjects.size` (used by presentation for the reported count, FR-006).
+
+---
+
+## SubjectExplorer (new) — pure core, no I/O side effects beyond the injected client
+
+```
+object SubjectExplorer {
+  def listAll(
+    client: SchemaRegistryClient,
+    filter: Option[String],
+  ): Either[DownloadError, SubjectListing]
+}
+```
+
+Behavior:
+1. `getAllSubjects()` → sorted `List[String]`; on failure ⇒ `Left(SubjectListFailed(e))`.
+2. For each subject (concurrently on a bounded pool sized by `schemaRegistryParallelism`, D4; `1` = sequential): `getAllVersions(subject)` → `List[Int]`; on failure ⇒ `Left(SubjectVersionsFetchFailed(subject, e))`, first error (in subject order) wins (fail-fast, clarified).
+3. `getCompatibility(subject)` → `Option[String]`, best-effort (`None` on absence/failure, D3).
+4. Build `SubjectListing(infos)`, then apply `filter.fold(listing)(listing.matching)`.
+
+The client is **injected** (Constitution II). No logging, no `sys.error` (FR-010).
+
+---
+
+## DownloadError (existing — one additive case)
+
+`DownloadError` is the existing sealed trait (`def message: String`, `def cause: Option[Throwable]`). Reused cases plus one new case:
+
+| Case | Status | Message |
+|---|---|---|
+| `SubjectListFailed(error: Throwable)` | reuse | `Failed to fetch subject list: {error.getMessage}` |
+| `SubjectVersionsFetchFailed(subject: String, error: Throwable)` | **new** | `Failed to fetch versions for {subject}: {error.getMessage}` (overrides `cause = Some(error)`) |
+
+Adding a case to the internal sealed trait is backward-compatible (the plugin owns all match sites).
+
+---
+
+## Setting / Task keys (in `SchemaDownloaderPlugin.autoImport`)
+
+| Key | Kind | Type | Default | Status |
+|---|---|---|---|---|
+| `schemaRegistryListSubjects` | `taskKey` | `Unit` | — | **new** |
+| `schemaRegistrySubjectFilter` | `settingKey` | `Option[String]` | `None` | **new** |
+
+Reused (read by the task, unchanged): `schemaRegistryUrl: String`, `schemaRegistryCacheSize: Int`, `schemaRegistryAuth: Option[SchemaRegistryAuth]`, `schemaRegistryProperties: Map[String, String]`.
+
+---
+
+## Relationships
+
+```
+schemaRegistryListSubjects (task, presentation/logging)
+        │ reads settings: Url, CacheSize, Auth, Properties, SubjectFilter
+        │ withRegistryClient(...) ──▶ SchemaRegistryClient (injected)
+        ▼
+SubjectExplorer.listAll(client, filter) : Either[DownloadError, SubjectListing]
+        │                                   ▲ Left = SubjectListFailed | SubjectVersionsFetchFailed
+        ▼
+SubjectListing(List[SubjectInfo])  ──matching(filter)──▶ SubjectListing
+        │
+        ▼
+SubjectInfo(name, versions, compatibility) ──▶ versionRange / latestVersion
+```
+
+Not reused: `RegistrySubject` (`Pinned`/`Latest`) models a download *selection*, not a discovered subject (D7).

--- a/specs/008-list-subjects-task/plan.md
+++ b/specs/008-list-subjects-task/plan.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Add a read-only sbt task `schemaRegistryListSubjects` that lists registry subjects — each with its version range and compatibility level — directly from sbt, for discovery and debugging. A pure core `SubjectExplorer.listAll(client, filter)` fetches and shapes the data into immutable value types (`SubjectInfo`, `SubjectListing`) and returns `Either[DownloadError, SubjectListing]`; all formatting and logging live only in the sbt task. An optional `schemaRegistrySubjectFilter` (case-insensitive substring) narrows the listing. The task reuses the existing client construction (`Downloader.buildClient` via `withRegistryClient`) and connection settings — no new connection config, fully additive, backward-compatible.
+Add a read-only sbt task `schemaRegistryListSubjects` that lists registry subjects — each with its version range and compatibility level — directly from sbt, for discovery and debugging. A pure core `SubjectExplorer.listAll(client, filter, parallelism)` fetches and shapes the data into immutable value types (`SubjectInfo`, `SubjectListing`) and returns `Either[DownloadError, SubjectListing]`; all formatting and logging live only in the sbt task. An optional `schemaRegistrySubjectFilter` (case-insensitive substring) narrows the listing — applied to subject names *before* fetching, so excluded subjects are never hit. Per-subject metadata is fetched concurrently via a shared `BoundedParallel.traverse` (also used by `ParallelDownloader`), reusing the existing `schemaRegistryParallelism` budget. The task reuses the existing client construction (`Downloader.buildClient` via `withRegistryClient`) and connection settings — no new connection config, fully additive, backward-compatible.
 
 ## Technical Context
 
@@ -22,7 +22,7 @@ Add a read-only sbt task `schemaRegistryListSubjects` that lists registry subjec
 
 **Project Type**: Single published sbt plugin (one project + `it/` integration subproject)
 
-**Performance Goals**: Interactive discovery; sequential per-subject fetch acceptable (research D4). No latency target — correctness and simplicity prioritized.
+**Performance Goals**: Interactive discovery. Per-subject metadata (versions + compatibility) fetched concurrently on a bounded pool sized by `schemaRegistryParallelism` (research D4); `1` = sequential. No hard latency target.
 
 **Constraints**: `-Xfatal-warnings` (no warnings tolerated); backward compatibility of all published keys/tasks; no new runtime dependency
 
@@ -69,14 +69,17 @@ src/main/scala/org/galaxio/avro/
 │                                  #         settingKey schemaRegistrySubjectFilter (default None),
 │                                  #         default in defaultSettings, root→Compile delegation + task body
 ├── DownloadError.scala            # MODIFY: add case SubjectVersionsFetchFailed(subject, error)
+├── ParallelDownloader.scala       # MODIFY: route through shared BoundedParallel.traverse (no dup pool code)
+├── BoundedParallel.scala          # NEW: bounded, order-preserving traverse; shared by ParallelDownloader + SubjectExplorer
 ├── SubjectInfo.scala              # NEW: value type (name, versions, compatibility) + versionRange/latestVersion
-├── SubjectListing.scala           # NEW: value type wrapping List[SubjectInfo] + matching(filter)
-└── SubjectExplorer.scala          # NEW: pure core listAll(client, filter): Either[DownloadError, SubjectListing]
+├── SubjectListing.scala           # NEW: value type wrapping List[SubjectInfo] + matching(filter) + nameMatches predicate
+└── SubjectExplorer.scala          # NEW: pure core listAll(client, filter, parallelism): Either[DownloadError, SubjectListing]
 
 src/test/scala/org/galaxio/avro/
-├── SubjectExplorerSpec.scala      # NEW: mock client — extraction, sort, filter, fail-fast, best-effort compat
+├── SubjectExplorerSpec.scala      # NEW: mock client — extraction, sort, filter, fail-fast (incl. parallel + first-error order), best-effort compat
 ├── SubjectInfoSpec.scala          # NEW: versionRange / latestVersion edge cases
-└── SubjectListingSpec.scala       # NEW: matching() case-insensitive substring, empty filter
+├── SubjectListingSpec.scala       # NEW: matching() case-insensitive substring, empty filter
+└── BoundedParallelSpec.scala      # NEW: order preserved, sequential vs parallel, concurrency proof
 
 it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala   # NEW: integration spec — real registry list + filter (Testcontainers; mirrors SubjectResolverIntegrationSpec)
 
@@ -90,7 +93,7 @@ src/sbt-test/schema-registry/list-subjects/   # NEW scripted e2e (mirror downloa
 
 ## Phase 0 — Research
 
-Complete. See [research.md](research.md). Decisions: D1 reuse `DownloadError` (+`SubjectVersionsFetchFailed`, not `RegistryError.FetchFailed`); D2 no cats → stdlib; D3 best-effort compatibility; D4 sequential v1 (parallel deferred); D5 new `schemaRegistrySubjectFilter` case-insensitive substring; D6 client methods `getAllSubjects`/`getAllVersions`/`getCompatibility`; D7 new value types (not reuse `RegistrySubject`); D8 `taskKey[Unit]` mirroring existing tasks; D9 three-tier testing (scripted asserts success/failure, content via `it/`). No `NEEDS CLARIFICATION` remain.
+Complete. See [research.md](research.md). Decisions: D1 reuse `DownloadError` (+`SubjectVersionsFetchFailed`, not `RegistryError.FetchFailed`); D2 no cats → stdlib; D3 best-effort compatibility; D4 parallel per-subject fetch reusing `schemaRegistryParallelism` (via shared `BoundedParallel.traverse`); D5 new `schemaRegistrySubjectFilter` case-insensitive substring; D6 client methods `getAllSubjects`/`getAllVersions`/`getCompatibility`; D7 new value types (not reuse `RegistrySubject`); D8 `taskKey[Unit]` mirroring existing tasks; D9 three-tier testing (scripted asserts success/failure, content via `it/`). No `NEEDS CLARIFICATION` remain.
 
 ## Phase 1 — Design & Contracts
 

--- a/specs/008-list-subjects-task/plan.md
+++ b/specs/008-list-subjects-task/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: List Subjects Task
+
+**Branch**: `008-list-subjects-task` | **Date**: 2026-06-20 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/008-list-subjects-task/spec.md` (issue [#32](https://github.com/galax-io/sbt-schema-registry-plugin/issues/32))
+
+## Summary
+
+Add a read-only sbt task `schemaRegistryListSubjects` that lists registry subjects — each with its version range and compatibility level — directly from sbt, for discovery and debugging. A pure core `SubjectExplorer.listAll(client, filter)` fetches and shapes the data into immutable value types (`SubjectInfo`, `SubjectListing`) and returns `Either[DownloadError, SubjectListing]`; all formatting and logging live only in the sbt task. An optional `schemaRegistrySubjectFilter` (case-insensitive substring) narrows the listing. The task reuses the existing client construction (`Downloader.buildClient` via `withRegistryClient`) and connection settings — no new connection config, fully additive, backward-compatible.
+
+## Technical Context
+
+**Language/Version**: Scala 2.12.21 (sbt's Scala), sbt 1.12.x autoplugin API
+
+**Primary Dependencies**: Confluent `kafka-schema-registry-client` 8.2.1 (`SchemaRegistryClient`); Scala standard library only — **no cats** (issue's cats syntax replaced with stdlib `Try`/`Either`/`foldLeft`, see research D2)
+
+**Storage**: N/A (reads from a remote Schema Registry; no local persistence)
+
+**Testing**: ScalaTest 3.2.x + mockito-scala (unit), Testcontainers (`it/test`, real Schema Registry + Kafka), sbt `scripted` (plugin e2e)
+
+**Target Platform**: JVM (Java 17+); runs inside an sbt build
+
+**Project Type**: Single published sbt plugin (one project + `it/` integration subproject)
+
+**Performance Goals**: Interactive discovery; sequential per-subject fetch acceptable (research D4). No latency target — correctness and simplicity prioritized.
+
+**Constraints**: `-Xfatal-warnings` (no warnings tolerated); backward compatibility of all published keys/tasks; no new runtime dependency
+
+**Scale/Scope**: Client-manageable subject counts (thousands, not millions); full list fetched and filtered client-side. ~3 new core files + 2 new keys + 1 new error case + 3 test tiers.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 and re-checked after Phase 1.*
+
+| Principle | Assessment | Status |
+|---|---|---|
+| I. Backward Compatibility | Only additive: 1 new `taskKey`, 1 new `settingKey` (default `None`), 1 new internal `DownloadError` case. No existing key/task/behavior changes. | ✅ PASS |
+| II. Single Responsibility | `SubjectExplorer` fetches+transforms (returns `Either`, no logging); `SubjectInfo`/`SubjectListing` are pure value types; presentation only in the task. Client is **injected**. | ✅ PASS |
+| III. Test-First | Unit (mock client) + integration (`it/`, real registry, no HTTP mocking) + scripted e2e. Tests authored before implementation. | ✅ PASS |
+| IV. Trunk-Based Release | No release-process impact at plan stage; work branches from `main`. | ✅ PASS |
+| V. Format & Verify | Plain Scala compiles clean under `-Xfatal-warnings`; `scalafmtAll`/`scalafmtSbt` before commit; CI gate unchanged. | ✅ PASS |
+
+**Result**: PASS — no violations. Complexity Tracking not required.
+
+*Post-Phase-1 re-check*: Design introduces no new dependency, no new project, no cross-class responsibility bleed, no public-API break. Still PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-list-subjects-task/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions D1–D9
+├── data-model.md        # Phase 1 — entities & keys
+├── quickstart.md        # Phase 1 — validation scenarios V1–V6
+├── contracts/
+│   └── plugin-api.md     # Phase 1 — sbt keys + core API contract
+├── checklists/
+│   └── requirements.md   # spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 — created by /speckit-tasks (NOT here)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/avro/
+├── SchemaDownloaderPlugin.scala   # MODIFY: add taskKey schemaRegistryListSubjects,
+│                                  #         settingKey schemaRegistrySubjectFilter (default None),
+│                                  #         default in defaultSettings, root→Compile delegation + task body
+├── DownloadError.scala            # MODIFY: add case SubjectVersionsFetchFailed(subject, error)
+├── SubjectInfo.scala              # NEW: value type (name, versions, compatibility) + versionRange/latestVersion
+├── SubjectListing.scala           # NEW: value type wrapping List[SubjectInfo] + matching(filter)
+└── SubjectExplorer.scala          # NEW: pure core listAll(client, filter): Either[DownloadError, SubjectListing]
+
+src/test/scala/org/galaxio/avro/
+├── SubjectExplorerSpec.scala      # NEW: mock client — extraction, sort, filter, fail-fast, best-effort compat
+├── SubjectInfoSpec.scala          # NEW: versionRange / latestVersion edge cases
+└── SubjectListingSpec.scala       # NEW: matching() case-insensitive substring, empty filter
+
+it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala   # NEW: integration spec — real registry list + filter (Testcontainers; mirrors SubjectResolverIntegrationSpec)
+
+src/sbt-test/schema-registry/list-subjects/   # NEW scripted e2e (mirror download-wildcard)
+├── build.sbt                      # uses RegistryFixture.url, schemaRegistrySubjectFilter
+├── project/plugins.sbt|docker.sbt # fixture wiring
+└── test                           # > schemaRegistryListSubjects (success), filtered run, negative (->)
+```
+
+**Structure Decision**: Single sbt-plugin project (the repo's established layout). Core logic in small single-responsibility files under `src/main/scala/org/galaxio/avro`, mirroring siblings (`SubjectResolver`, `Downloader`). Presentation stays in `SchemaDownloaderPlugin`. Tests span the project's three tiers (`src/test`, `it/`, `src/sbt-test`).
+
+## Phase 0 — Research
+
+Complete. See [research.md](research.md). Decisions: D1 reuse `DownloadError` (+`SubjectVersionsFetchFailed`, not `RegistryError.FetchFailed`); D2 no cats → stdlib; D3 best-effort compatibility; D4 sequential v1 (parallel deferred); D5 new `schemaRegistrySubjectFilter` case-insensitive substring; D6 client methods `getAllSubjects`/`getAllVersions`/`getCompatibility`; D7 new value types (not reuse `RegistrySubject`); D8 `taskKey[Unit]` mirroring existing tasks; D9 three-tier testing (scripted asserts success/failure, content via `it/`). No `NEEDS CLARIFICATION` remain.
+
+## Phase 1 — Design & Contracts
+
+Complete. Artifacts: [data-model.md](data-model.md) (entities, keys, the additive error case), [contracts/plugin-api.md](contracts/plugin-api.md) (sbt keys + core API + backward-compat assertions), [quickstart.md](quickstart.md) (V1–V6 validation mapped to spec items). Agent context (`CLAUDE.md` SPECKIT block) updated to point at this plan.
+
+## Phase 2 — Task planning approach (for `/speckit-tasks`, not executed here)
+
+Expected decomposition, test-first and dependency-ordered:
+1. Pure value types + their unit tests (`SubjectInfo`, `SubjectListing`) — no client needed.
+2. `DownloadError.SubjectVersionsFetchFailed` case.
+3. `SubjectExplorer.listAll` + `SubjectExplorerSpec` (mock client) — depends on 1–2.
+4. Plugin wiring: keys, default, task body — depends on 3.
+5. Integration spec (`it/`) — depends on 3.
+6. Scripted e2e `list-subjects/` — depends on 4.
+7. Format/verify gate (`scalafmt*`, `compile test`, `it/test`, `scripted`).
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/008-list-subjects-task/quickstart.md
+++ b/specs/008-list-subjects-task/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart / Validation: List Subjects Task
+
+**Feature**: 008-list-subjects-task | **Date**: 2026-06-20
+
+How to prove the feature works end to end. References [contracts/plugin-api.md](contracts/plugin-api.md) and [data-model.md](data-model.md) for shapes; no implementation code here.
+
+## Prerequisites
+
+- Java 17+, sbt 1.12.x (`sbt` Scala 2.12.21).
+- Docker running (for `it/test` and `scripted` Testcontainers). Local runs may need a `DOCKER_HOST` + Docker socket override for Testcontainers to reach the daemon.
+
+## Build / verify commands
+
+```bash
+sbt scalafmtAll scalafmtSbt                          # format (run before commit)
+sbt scalafmtCheckAll scalafmtSbtCheck compile test   # CI gate (unit)
+sbt it/test                                          # integration (Docker)
+sbt scripted                                         # plugin e2e (Docker)
+```
+
+## Validation scenarios
+
+### V1 — Core listing (unit, `SubjectExplorerSpec`)
+- **Setup**: mock `SchemaRegistryClient`; stub `getAllSubjects` → `["user-value","order-value","payment-value"]`, `getAllVersions` per subject, `getCompatibility` (one `BACKWARD`, one throwing).
+- **Run**: `SubjectExplorer.listAll(client, None)`.
+- **Expect**: `Right(SubjectListing(...))`, subjects sorted by name; each `versionRange` correct (single vs `1..5`); the throwing-compat subject ⇒ `compatibility = None`. (Covers US1, US3, FR-003/004/005/012.)
+
+### V2 — Filter (unit, `SubjectListingSpec` + `SubjectExplorerSpec`)
+- **Run**: `listing.matching("ORDER")` and `SubjectExplorer.listAll(client, Some("order"))`.
+- **Expect**: only `order-value`; case-insensitive; empty filter ⇒ all. (Covers US2, FR-007/008.)
+
+### V3 — Fail-fast on version error (unit)
+- **Setup**: `getAllVersions("order-value")` throws.
+- **Run**: `SubjectExplorer.listAll(client, None)`.
+- **Expect**: `Left(DownloadError.SubjectVersionsFetchFailed("order-value", _))`; no partial listing. (Covers fail-fast clarification, FR-010.)
+
+### V4 — Subject-list failure (unit)
+- **Setup**: `getAllSubjects` throws.
+- **Expect**: `Left(DownloadError.SubjectListFailed(_))`. (Covers edge "registry unreachable", FR-011.)
+
+### V5 — Real registry (integration, `it/`)
+- **Setup**: Testcontainers Schema Registry; register 2+ subjects, one with multiple versions and a subject-level compatibility override.
+- **Run**: `SubjectExplorer.listAll(realClient, None)` and with a filter.
+- **Expect**: real version ranges and the override level surface correctly; filter narrows results. No HTTP mocking (Constitution III). (Covers US1/US2/US3 against real protocol.)
+
+### V6 — sbt wiring (scripted, `src/sbt-test/schema-registry/list-subjects/`)
+- **Setup**: mirror `download-wildcard`; `docker.sbt` fixture + `RegistryFixture`; `schemaRegistryUrl := RegistryFixture.url`.
+- **`test` script**:
+  - `> schemaRegistryListSubjects` — must **succeed** (all subjects).
+  - `> set schemaRegistrySubjectFilter := Some("Order")` then `> schemaRegistryListSubjects` — must succeed (filtered).
+  - Negative project (bad URL): `-> schemaRegistryListSubjects` — must **fail**.
+- **Note**: scripted asserts task success/failure (no stdout-grep statement exists); listed-content correctness is proven by V5. (Covers FR-001/002/013.)
+
+## Done / acceptance mapping
+
+| Spec item | Validated by |
+|---|---|
+| US1 list all + count | V1, V5, V6 |
+| US2 filter | V2, V5, V6 |
+| US3 versions + compatibility | V1, V5 |
+| Fail-fast / unreachable | V3, V4, V6(neg) |
+| Backward compatibility (FR-013) | existing `download-*` scripted tests stay green |
+| Format + `-Xfatal-warnings` (Constitution V) | `scalafmtCheckAll … compile` gate |

--- a/specs/008-list-subjects-task/research.md
+++ b/specs/008-list-subjects-task/research.md
@@ -1,0 +1,133 @@
+# Research: List Subjects Task
+
+**Feature**: 008-list-subjects-task | **Date**: 2026-06-20
+
+Phase 0 decisions resolving every unknown in the Technical Context. Findings are grounded in a full read of the existing plugin source (`SchemaDownloaderPlugin`, `Downloader`, `SubjectResolver`, `ParallelDownloader`, `DownloadError`, `RegistryError`, `SchemaRegistryAuth`, build files, and the unit/integration/scripted test harnesses).
+
+---
+
+## D1 — Error model: reuse `DownloadError`, do not introduce `RegistryError.FetchFailed`
+
+**Decision**: Model listing failures with the existing `DownloadError` sealed trait. Reuse `SubjectListFailed(error)` for a failed `getAllSubjects` call. Add one new case `SubjectVersionsFetchFailed(subject: String, error: Throwable)` for a per-subject version-fetch failure. Compatibility-lookup failures are **not** modeled as errors (see D3).
+
+**Rationale**:
+- Issue #32 references `RegistryError.FetchFailed(subject, cause)`, but `RegistryError` has no such case (its cases: `FileNotFound`, `FileReadFailed`, `RegistrationFailed`, `CompatibilityCheckFailed`, `UnsupportedSchemaType`) — those model *registration* and *file* failures.
+- `DownloadError` already models registry *read* failures and even has `SubjectListFailed("Failed to fetch subject list: …")` — an exact fit for the `getAllSubjects` failure path. Listing is a read operation in the download domain.
+- Adding one precise case keeps the project's granular error style (`DownloadError` already has 9 cases) and produces an accurate message ("Failed to fetch versions for {subject}: …") rather than overloading `SchemaFetchFailed` ("Failed to fetch schema {subject}").
+- `DownloadError` is an internal sealed trait used only inside the plugin; adding a case is backward-compatible (no public match sites break — the plugin owns all matches).
+
+**Alternatives considered**:
+- *Add `RegistryError.FetchFailed`* (as the issue sketched) — rejected: wrong ADT (`RegistryError` is the registration/file domain), and would duplicate `SubjectListFailed`.
+- *Reuse `SchemaFetchFailed` for version fetch* — rejected: imprecise message; the granular-error convention favors a dedicated case.
+
+---
+
+## D2 — No cats: plain Scala only
+
+**Decision**: Implement the core with the Scala standard library. No new dependency.
+
+**Rationale**: The project has **no cats dependency** (confirmed in `project/Dependencies.scala`) and compiles with `-Xfatal-warnings`. The constitution requires approval for new deps. Issue #32's snippet used cats syntax (`Either.catchNonFatal`, `.leftMap`, `.traverse`); these translate directly:
+
+| Issue #32 (cats) | Plan (stdlib) |
+|---|---|
+| `Either.catchNonFatal(expr).leftMap(f)` | `Try(expr).toEither.left.map(f)` |
+| `names.traverse(fetchInfo)` | a `foldLeft` over `names` short-circuiting on the first `Left` (or a tail-recursive helper), returning `Either[DownloadError, List[SubjectInfo]]` |
+| `Option(client.getCompatibility(s)).recover { case _ => None }` | `Try(Option(client.getCompatibility(s))).toOption.flatten` |
+
+**Alternatives considered**: *Add cats-core* — rejected: needs approval, disproportionate for one traverse, and the existing codebase (`SubjectResolver`, `Downloader`) already does `Either` for-comprehensions and manual accumulation in plain Scala.
+
+---
+
+## D3 — Compatibility is best-effort
+
+**Decision**: `getCompatibility(subject)` is wrapped so that *any* failure or absence yields `None`, never an error. The presentation layer renders `None` as `(default)`.
+
+**Rationale**: Confluent's `getCompatibility(subject)` throws `RestClientException` (HTTP 404, code 40401) when no **subject-level** compatibility override exists — the common case where the global default applies. Treating that as a failure would make most listings fail. FR-012 mandates best-effort. Only `getAllSubjects` (D1) and `getAllVersions` (D1) are hard-fail paths.
+
+---
+
+## D4 — Concurrency: parallel per-subject fetch, reusing `schemaRegistryParallelism`
+
+**Decision**: Fetch each subject's versions + compatibility concurrently on a bounded thread pool sized by the existing `schemaRegistryParallelism` setting (`1` = sequential, max `32`). Mirror `ParallelDownloader`'s pattern: `Executors.newFixedThreadPool(parallelism)` + `Future.sequence` + `Await`, pool shut down in `finally`. Fail-fast preserved: the first `Left` (in subject order) wins.
+
+**Rationale**: A registry with hundreds of subjects means `2N` HTTP calls (`getAllVersions` + `getCompatibility` per subject). The plugin already ships a parallel downloader; doing listing sequentially while downloads are parallel is inconsistent and needlessly slow. Reusing `schemaRegistryParallelism` (already validated 1–32) keeps one knob for the user. `SchemaRegistryClient` (`CachedSchemaRegistryClient`) is thread-safe and already used concurrently by `ParallelDownloader`. `parallelism == 1` keeps the simple sequential, short-circuiting `foldLeft` path.
+
+**Note**: This supersedes the initial "sequential v1" decision (the deferred `/speckit-clarify` perf item) — implemented directly at the maintainer's request rather than deferred.
+
+**Alternatives considered**:
+- *Sequential only* — rejected: inconsistent with the parallel download task; slow on large registries.
+- *Separate `schemaRegistryListParallelism` setting* — rejected: an extra knob for no benefit; the download budget is the right reuse.
+
+---
+
+## D5 — Filter: new `schemaRegistrySubjectFilter` setting, case-insensitive substring
+
+**Decision**: Add `schemaRegistrySubjectFilter: settingKey[Option[String]]`, default `None`. When `Some(text)`, keep subjects whose name contains `text` ignoring case (`name.toLowerCase.contains(text.toLowerCase)`). Empty string ⇒ matches all.
+
+**Rationale**: Matches issue #32's `schemaRegistrySubjectFilter := Some("order")` and the `/speckit-clarify` decision (case-insensitive substring). Deliberately distinct from the existing `schemaRegistrySubjectPatterns: Seq[String]` (regex, full-match, used by *download*) — different semantics and different task; overloading that key would conflate download-selection with list-display filtering. Additive new key ⇒ backward compatible.
+
+---
+
+## D6 — Client API surface (Confluent `kafka-schema-registry-client` 8.2.1)
+
+**Decision**: Use these `SchemaRegistryClient` methods, converting Java collections via `scala.collection.JavaConverters` (Scala 2.12):
+
+| Method | Returns | Use |
+|---|---|---|
+| `getAllSubjects()` | `java.util.Collection[String]` | all subject names → `.asScala.toList.sorted` (already used by `SubjectResolver`) |
+| `getAllVersions(subject)` | `java.util.List[Integer]` | versions → `.asScala.map(_.intValue).toList` |
+| `getCompatibility(subject)` | `String` | subject-level compatibility; throws when unset → best-effort `None` (D3) |
+
+**Rationale**: `getAllSubjects` is already in use, confirming the conversion idiom. `getAllVersions`/`getCompatibility` are standard `SchemaRegistryClient` interface methods present in 8.2.1. No new client capability required (FR-002: reuse existing connection).
+
+---
+
+## D7 — Value types: new `SubjectInfo` + `SubjectListing`
+
+**Decision**: Introduce two immutable value types (one file each, per the single-responsibility file convention):
+- `SubjectInfo(name: String, versions: List[Int], compatibility: Option[String])` with derived `latestVersion: Option[Int]` and `versionRange: String`.
+- `SubjectListing(subjects: List[SubjectInfo])` with a pure `matching(filter: String): SubjectListing`.
+
+Do **not** reuse `RegistrySubject` (sealed `Pinned`/`Latest`) — it models a download selection (name + optional pinned version), not a discovered subject's full version list + compatibility.
+
+**Rationale**: Directly testable value types as issue #32 specifies; keep presentation (formatting/logging) out of them (FR-009).
+
+---
+
+## D8 — Task shape and wiring
+
+**Decision**:
+- Add `schemaRegistryListSubjects = taskKey[Unit]("List subjects in the schema registry")`.
+- Body mirrors existing tasks exactly: `val logger = streams.value.log`; read settings via `.value`; `withRegistryClient(url, cacheSize, auth, properties) { client => SubjectExplorer.listAll(client, filter) match { case Left(e) => sys.error(e.message); case Right(listing) => /* log */ } }`.
+- Core: `object SubjectExplorer { def listAll(client: SchemaRegistryClient, filter: Option[String]): Either[DownloadError, SubjectListing] }`.
+
+**Rationale**: `taskKey[Unit]` matches all three existing tasks (`Download`/`Register`/`TestCompatibility`) and the "presentation at the edge" design. The core returns `Either[DownloadError, SubjectListing]` (no logging, no `sys.error`) per FR-009/FR-010. Insertion points (from the source map): new `taskKey` after the last key (~line 34), new `settingKey` near the others, default `None` in `defaultSettings` (~line 49), root→`Compile`-scoped delegation + body appended to `projectSettings` (after ~line 263). All additive ⇒ FR-013 backward compatibility holds.
+
+---
+
+## D9 — Testing strategy (three tiers, test-first)
+
+**Decision**:
+- **Unit** (`src/test`, mockito-scala): `SubjectExplorerSpec` stubs `getAllSubjects`/`getAllVersions`/`getCompatibility` and verifies data extraction, sorting, filtering, fail-fast on version-fetch error, and best-effort compatibility. `SubjectInfoSpec` / `SubjectListingSpec` for pure derived values (`versionRange`, `latestVersion`, `matching`).
+- **Integration** (`it/`, Testcontainers): register subjects in a real Schema Registry, call `SubjectExplorer.listAll`, assert real version ranges and compatibility — no HTTP mocking (Constitution III).
+- **Scripted e2e** (`src/sbt-test/schema-registry/list-subjects/`): mirror `download-wildcard`, use the `docker.sbt` + `RegistryFixture` fixture, run `schemaRegistryListSubjects` and assert the task **succeeds**; a negative case asserts failure on an unreachable registry (`-> schemaRegistryListSubjects`).
+
+**Rationale / limitation**: sbt `scripted` asserts on file side-effects and task success/failure, **not** on logged stdout (no `must-contain` statement exists). Content correctness (versions, compatibility, filter results) is therefore proven by the `it/` integration test against a real registry; the scripted test proves the sbt wiring (task runs, settings honored, failure surfaces). If log-content assertion is later required, the scripted build can add a tiny check task that writes `SubjectExplorer` output to a file and assert with `$ must-mirror`.
+
+---
+
+## Resolved unknowns summary
+
+| Unknown | Resolution |
+|---|---|
+| Which error ADT? | `DownloadError` (+ one new `SubjectVersionsFetchFailed` case) — D1 |
+| cats available? | No → plain stdlib — D2 |
+| Compatibility-absent handling | Best-effort `None` → `(default)` — D3 |
+| Sequential vs parallel fetch | Sequential v1; parallel deferred — D4 |
+| Filter key & semantics | New `schemaRegistrySubjectFilter: Option[String]`, case-insensitive substring — D5 |
+| Client methods | `getAllSubjects` / `getAllVersions` / `getCompatibility` (8.2.1) — D6 |
+| Reuse `RegistrySubject`? | No; new `SubjectInfo`/`SubjectListing` — D7 |
+| Task return type | `Unit` (logs); core returns `Either[DownloadError, SubjectListing]` — D8 |
+| Log-content e2e assertion | Covered by `it/`; scripted asserts success/failure — D9 |
+
+No `NEEDS CLARIFICATION` remain.

--- a/specs/008-list-subjects-task/spec.md
+++ b/specs/008-list-subjects-task/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: List Subjects Task
+
+**Feature Branch**: `008-list-subjects-task`
+
+**Created**: 2026-06-20
+
+**Status**: Draft
+
+**Input**: GitHub issue #32 — "feat: list subjects task for discovery and debugging". A `schemaRegistryListSubjects` sbt task that lists registry subjects (with versions and compatibility) directly from sbt, so developers can discover and debug what exists in the registry without reaching for `curl` or a separate UI.
+
+## Clarifications
+
+### Session 2026-06-20
+
+- Q: Filter matching semantics — substring case-sensitive, substring case-insensitive, or full-match regex? → A: Substring, case-insensitive (subject name contains the filter text, ignoring case).
+- Q: When a subject's versions can't be fetched after it appeared in the subject list — fail-fast or partial results? → A: Fail-fast — the whole task fails with a message naming the affected subject (version fetch is fatal; compatibility lookup stays best-effort).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discover All Subjects from sbt (Priority: P1)
+
+A plugin user is configuring schema downloads but does not remember which subjects exist in the registry. Instead of running `curl http://localhost:8081/subjects` or opening a separate UI, they run a single sbt task. The task connects to the registry using the build's existing connection settings, fetches every subject with its available versions and compatibility level, and prints a readable, sorted listing to the sbt log.
+
+**Why this priority**: Core value proposition. Discovery directly from the build tool — using the connection settings already configured — is the whole point of the feature. Without it there is nothing to filter or inspect.
+
+**Independent Test**: Register several subjects in a real Schema Registry, run the list task, and verify the log shows every registered subject with its version range and compatibility level.
+
+**Acceptance Scenarios**:
+
+1. **Given** the registry contains subjects `["user-value", "order-value", "payment-value"]`, **When** the user runs the list task, **Then** the log reports the total subject count and lists all three subjects sorted by name, each with its version range and compatibility level.
+2. **Given** a subject has multiple registered versions (e.g. versions 1 through 5), **When** the user runs the list task, **Then** that subject's entry shows its version range (e.g. `1..5`).
+3. **Given** a subject has only one registered version, **When** the user runs the list task, **Then** that subject's entry shows the single version (e.g. `1`), not a range.
+4. **Given** the registry contains no subjects, **When** the user runs the list task, **Then** the task completes successfully and reports that zero subjects were found.
+
+---
+
+### User Story 2 - Filter Subjects by Pattern (Priority: P2)
+
+A user works against a registry with many subjects and only cares about a subset (e.g. everything related to `order`). They set a filter and run the list task. Only subjects whose names contain the filter text are listed; the reported count reflects the filtered result.
+
+**Why this priority**: Important for usability on large registries, but builds on P1 — the unfiltered listing is already useful on its own. Filtering is a refinement, not the foundation.
+
+**Independent Test**: Register subjects across several name groups, set a filter that matches only one group, run the list task, and verify only matching subjects appear and the count matches.
+
+**Acceptance Scenarios**:
+
+1. **Given** the registry contains `["user-value", "order-value", "payment-value"]` and the filter is set to `order`, **When** the user runs the list task, **Then** only `order-value` is listed and the reported count is 1.
+2. **Given** a filter is set that matches no subject names, **When** the user runs the list task, **Then** the task completes successfully and reports that zero subjects matched.
+3. **Given** no filter is set, **When** the user runs the list task, **Then** all subjects are listed (filtering is inactive by default).
+
+---
+
+### User Story 3 - Inspect Versions and Compatibility for Debugging (Priority: P3)
+
+A user is debugging a compatibility problem and wants to see, per subject, how many versions exist and what compatibility level governs evolution. The listing surfaces the version range and the compatibility level for each subject; when a subject has no subject-level compatibility override, the listing makes clear the global default applies.
+
+**Why this priority**: A debugging convenience layered on the listing from P1. Valuable, but the raw subject/version information already covers the most common discovery need.
+
+**Independent Test**: Register a subject with a subject-level compatibility override and another without one, run the list task, and verify the first shows its explicit level while the second is shown as using the default.
+
+**Acceptance Scenarios**:
+
+1. **Given** a subject has a subject-level compatibility setting (e.g. `BACKWARD`), **When** the user runs the list task, **Then** that subject's entry shows `BACKWARD`.
+2. **Given** a subject has no subject-level compatibility override, **When** the user runs the list task, **Then** that subject's entry indicates the default (global) compatibility applies rather than failing.
+
+---
+
+### Edge Cases
+
+- **Registry unreachable**: When the registry cannot be reached while fetching the subject list, the task fails with a clear connection error rather than printing a partial or empty listing as if it succeeded.
+- **Subject disappears mid-listing**: When a subject is returned by the subject list but its versions can no longer be fetched (e.g. deleted between calls), the task fails with a clear error identifying the affected subject. (See Assumptions for the fail-fast rationale.)
+- **Compatibility lookup fails or is absent**: A missing or unreadable subject-level compatibility setting does not fail the task; the subject is shown as using the default.
+- **Empty registry**: A registry with zero subjects completes successfully and reports zero subjects.
+- **Empty filter value**: A filter set to an empty string is treated as "match everything" (equivalent to no filter), not "match nothing".
+- **Large registry**: A registry with hundreds of subjects lists them all; the user is responsible for narrowing with a filter. The reported count communicates the scale.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a new sbt task `schemaRegistryListSubjects` that lists registry subjects to the sbt log.
+- **FR-002**: System MUST reuse the build's existing registry connection settings (URL, authentication, client properties) — the list task introduces no new connection configuration.
+- **FR-003**: System MUST fetch the complete set of subjects from the registry and present them sorted by subject name.
+- **FR-004**: System MUST report, for each subject, its available version range — a single value when one version exists, and a `first..last` range when multiple versions exist.
+- **FR-005**: System MUST report, for each subject, its compatibility level, clearly indicating when the subject uses the default (global) compatibility rather than a subject-level override.
+- **FR-006**: System MUST report the total number of subjects listed (after any filtering is applied).
+- **FR-007**: System MUST provide an optional filter setting that, when set, restricts the listing to subjects whose names contain the filter text (case-insensitive substring match).
+- **FR-008**: System MUST treat an unset (or empty) filter as "list all subjects".
+- **FR-009**: System MUST keep data retrieval and transformation separate from presentation — fetching and shaping the listing yields a result value, and all formatting and logging happen only in the sbt task layer. (Constitution Principle II: Single Responsibility.)
+- **FR-010**: System MUST surface retrieval failures as a typed error result rather than throwing from the core listing logic; the sbt task layer translates that error into a clear task failure message.
+- **FR-011**: System MUST fail the task with a clear, actionable message when the subject list cannot be fetched (e.g. registry unreachable).
+- **FR-012**: System MUST NOT fail the listing solely because a subject's compatibility level cannot be read; such subjects are reported as using the default compatibility.
+- **FR-013**: System MUST remain fully backward compatible — adding the list task and its optional filter setting MUST NOT change any existing key, task, or download behavior.
+
+### Key Entities
+
+- **SubjectInfo**: An immutable value describing one subject — its name, the list of available versions, and an optional compatibility level. Derived values include the latest version and a human-readable version range.
+- **SubjectListing**: An immutable collection of `SubjectInfo` values representing the result of a list operation. Supports a pure filter transformation that narrows the listing by a name pattern.
+- **DownloadError**: A typed representation of a retrieval failure (e.g. failure to fetch the subject list or a subject's versions), carrying enough context (which subject/operation) to produce an actionable message. Reuses the project's existing error-modeling approach — the plugin's existing `DownloadError` sealed type, which already models registry-read failures (`SubjectListFailed`) plus a new per-subject `SubjectVersionsFetchFailed` case. (Issue #32 sketched a `RegistryError.FetchFailed`; that case does not exist and `DownloadError` is the correct existing model — see plan research D1.)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can list every subject in a registry, with versions and compatibility, by running a single sbt task — no `curl`, no separate UI, no extra connection configuration.
+- **SC-002**: A user can narrow the listing to a subset of subjects by setting one filter value, and the reported count reflects only matching subjects.
+- **SC-003**: Each listed subject shows its version range and compatibility in a single, scannable line.
+- **SC-004**: When the registry is unreachable, the user gets an actionable failure message instead of an empty or misleading listing.
+- **SC-005**: Existing builds that do not use the list task are completely unaffected (zero breaking changes to existing keys, tasks, or download behavior).
+
+## Assumptions
+
+- **Substring filter semantics**: The filter matches subjects whose names *contain* the filter text (case-insensitive substring). Issue #32's reference code used a case-sensitive `.*pattern.*`; case-insensitivity was chosen during clarification because listing is an interactive discovery aid where casing mistakes should not hide results. This differs deliberately from the full-match, case-sensitive regex semantics of the wildcard-download feature (spec 004).
+- **Fail-fast on retrieval errors** (confirmed during clarification): If any subject's versions cannot be fetched after that subject appeared in the subject list, the entire task fails rather than emitting a partial listing. This keeps the listing trustworthy (a partial list could mislead discovery) and matches the error-accumulation behavior described in issue #32. Partial-results mode (continue past per-subject failures) is explicitly out of scope for this version.
+- **Compatibility is best-effort**: A subject-level compatibility lookup may legitimately be absent (no override) or fail; either case is reported as "default" and never fails the task. Only subject-list and version retrieval are treated as hard failures.
+- **Read-only**: The task only reads from the registry. It never registers, deletes, or mutates subjects, versions, or configuration.
+- **Output destination**: Results are presented through the standard sbt log (info level), consistent with other plugin tasks. Machine-readable output formats (JSON, file export) are out of scope for this version.
+- **Connection reuse**: The registry endpoint exposes the standard subject-list, subject-versions, and subject-compatibility operations available through the existing registry client; no new endpoints or client configuration are required.
+- **Scale**: The registry holds a client-manageable number of subjects (thousands, not millions); the full list is fetched and filtered client-side.

--- a/specs/008-list-subjects-task/tasks.md
+++ b/specs/008-list-subjects-task/tasks.md
@@ -61,7 +61,7 @@ Scala 2.12.21, sbt autoplugin, Confluent `kafka-schema-registry-client` 8.2.1, *
 
 ### Implementation for User Story 1
 
-- [x] T009 [US1] Implement src/main/scala/org/galaxio/avro/SubjectExplorer.scala — `object SubjectExplorer { def listAll(client: SchemaRegistryClient, filter: Option[String]): Either[DownloadError, SubjectListing] }`: `getAllSubjects().asScala.toList.sorted` (stdlib `Try(...).toEither.left.map(SubjectListFailed)`); per subject sequentially fetch `getAllVersions(...).asScala.map(_.intValue).toList` (left ⇒ `SubjectVersionsFetchFailed`) accumulating via `foldLeft` short-circuit; best-effort `getCompatibility` → `Option`; apply `filter.fold(listing)(listing.matching)` (makes T007 pass; depends on T002, T005, T006)
+- [x] T009 [US1] Implement src/main/scala/org/galaxio/avro/SubjectExplorer.scala — `object SubjectExplorer { def listAll(client, filter, parallelism = 1): Either[DownloadError, SubjectListing] }`: `getAllSubjects().asScala.toList.sorted` (stdlib `Try(...).toEither.left.map(SubjectListFailed)`); filter subject **names before fetch** via `SubjectListing.nameMatches`; per kept subject fetch `getAllVersions(...).asScala.map(_.intValue).toList.sorted` (left ⇒ `SubjectVersionsFetchFailed`) + best-effort `getCompatibility` → `Option`; collect via `firstError` (first Left in subject order wins). Bounded-concurrent fetch via `BoundedParallel.traverse` — see T023. (makes T007 pass; depends on T002, T005, T006)
 - [x] T010 [US1] Wire the task in src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala — add `schemaRegistryListSubjects = taskKey[Unit](...)` to `autoImport`; add root→`Compile`-scoped delegation; `Compile / schemaRegistryListSubjects` body mirrors existing tasks: `val logger = streams.value.log`; `withRegistryClient(url, cacheSize, auth, properties) { client => SubjectExplorer.listAll(client, None) match { case Left(e) => sys.error(e.message); case Right(listing) => log count + one line per subject (name padded, `versions: <range>`, `compat: <level|(default)>`) } }`
 - [x] T011 [US1] Create scripted e2e src/sbt-test/schema-registry/list-subjects/ mirroring `download-wildcard`: `build.sbt` (`schemaRegistryUrl := RegistryFixture.url`), `project/` fixture wiring (`docker.sbt`/`plugins.sbt`), and `test` script asserting `> schemaRegistryListSubjects` SUCCEEDS; add a bad-URL negative path asserting `-> schemaRegistryListSubjects` FAILS
 
@@ -116,6 +116,18 @@ Scala 2.12.21, sbt autoplugin, Confluent `kafka-schema-registry-client` 8.2.1, *
 - [x] T020 [P] Document `schemaRegistryListSubjects` and `schemaRegistrySubjectFilter` (usage + sample output) in README.md (and in AGENTS.md task list if one is maintained)
 - [x] T021 Full verify — `sbt scalafmtAll scalafmtSbt` then `sbt scalafmtCheckAll scalafmtSbtCheck compile test`, `sbt it/test`, `sbt scripted` all green (confirms FR-013 backward compat: existing `download-*`/`register-*` scripted tests still pass)
 - [x] T022 [P] Execute [quickstart.md](quickstart.md) scenarios V1–V6 and confirm each acceptance mapping holds
+
+---
+
+## Phase 7: Post-tasks (delivered via review rounds)
+
+**Purpose**: Work that arose after `/speckit-tasks` from code-review feedback and a maintainer request to parallelize listing. Tracked here for traceability; all landed in PR #55 with tests.
+
+- [x] T023 [P] Extract src/main/scala/org/galaxio/avro/BoundedParallel.scala — `traverse[A,B](items, parallelism)(f)`: bounded, order-preserving, pool sized to `min(parallelism, items.size)`, `<= 1` = sequential (no pool), shutdown in `finally`. Wire `SubjectExplorer.fetchInfos` to it and add the `parallelism` param to `listAll`, reusing `schemaRegistryParallelism` (validated `1..32` in the task body like the download task). Add BoundedParallelSpec. (resolves the deferred perf item, research D4)
+- [x] T024 Refactor src/main/scala/org/galaxio/avro/ParallelDownloader.scala to consume `BoundedParallel.traverse` — remove the duplicated thread-pool/`Future`/`Await`/shutdown code; public API unchanged. Existing `ParallelDownloaderSpec` + integration spec confirm no regression. (reuse, not duplication)
+- [x] T025 [P] Consolidate the case-insensitive substring predicate into `SubjectListing.nameMatches` (used by both `SubjectExplorer.filterNames` pre-fetch and `SubjectListing.matching`); make `SubjectExplorer.firstError` a single-pass `foldLeft` preserving first-error order; wrap the bounded fetch in `Try` so the core never throws on an `Await` timeout/interrupt (FR-010). Add the multi-failure first-error-order test.
+
+**Checkpoint**: parallel listing reuses the shared `BoundedParallel` primitive; no duplicated concurrency code; core stays pure and no-throw.
 
 ---
 

--- a/specs/008-list-subjects-task/tasks.md
+++ b/specs/008-list-subjects-task/tasks.md
@@ -1,0 +1,187 @@
+---
+description: "Task list for List Subjects Task (008)"
+---
+
+# Tasks: List Subjects Task
+
+**Input**: Design documents from `specs/008-list-subjects-task/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/plugin-api.md](contracts/plugin-api.md), [quickstart.md](quickstart.md)
+
+**Tests**: INCLUDED — the constitution mandates test-first (unit + integration + scripted) and the spec's acceptance criteria require them. Write each test FIRST and confirm it FAILS before the implementation task that makes it pass.
+
+**Organization**: Grouped by user story. MVP = User Story 1.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different file, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (story phases only)
+- All paths are repository-relative.
+
+## Stack reminder (from plan.md)
+
+Scala 2.12.21, sbt autoplugin, Confluent `kafka-schema-registry-client` 8.2.1, **stdlib only — no cats**, `-Xfatal-warnings`. Format with `scalafmtAll`/`scalafmtSbt` before commit. Mirror existing sibling files (`SubjectResolver`, `Downloader`, `DownloadError`).
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm a clean baseline before additive changes.
+
+- [x] T001 Verify clean baseline — run `sbt scalafmtCheckAll scalafmtSbtCheck compile test` and confirm green before making changes
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared, pure domain types + error case that every user story depends on. Pure value types are test-first and self-contained here.
+
+**⚠️ CRITICAL**: No user-story work begins until this phase is complete.
+
+- [x] T002 [P] Add `final case class SubjectVersionsFetchFailed(subject: String, error: Throwable)` to `DownloadError` (message `Failed to fetch versions for $subject: ${error.getMessage}`, `override def cause = Some(error)`) in src/main/scala/org/galaxio/avro/DownloadError.scala
+- [x] T003 [P] Write FAILING unit test src/test/scala/org/galaxio/avro/SubjectInfoSpec.scala — `versionRange` for empty (`none`), single (`3`), many (`1..5`); `latestVersion` = last/None
+- [x] T004 [P] Write FAILING unit test src/test/scala/org/galaxio/avro/SubjectListingSpec.scala — `matching` keeps case-insensitive substring matches; `Some("")`/empty filter ⇒ all; `size`
+- [x] T005 [P] Implement src/main/scala/org/galaxio/avro/SubjectInfo.scala — `final case class SubjectInfo(name: String, versions: List[Int], compatibility: Option[String])` with `latestVersion` and `versionRange` (makes T003 pass)
+- [x] T006 [P] Implement src/main/scala/org/galaxio/avro/SubjectListing.scala — `final case class SubjectListing(subjects: List[SubjectInfo])` with `size` and `matching(filter: String)` (case-insensitive `contains`) (makes T004 pass)
+
+**Checkpoint**: Pure types + error case compile and their unit tests pass — the engine for all stories is ready.
+
+---
+
+## Phase 3: User Story 1 — Discover All Subjects from sbt (Priority: P1) 🎯 MVP
+
+**Goal**: `sbt schemaRegistryListSubjects` connects with the build's existing settings, fetches every subject (sorted) with versions + compatibility, prints count + one line per subject. Fails clearly when the registry is unreachable.
+
+**Independent Test**: Register subjects in a registry, run the task → log shows the count and every subject with its version range and compatibility; with a bad URL the task fails with an actionable message.
+
+### Tests for User Story 1 (write first, must FAIL)
+
+- [x] T007 [P] [US1] Write FAILING unit test src/test/scala/org/galaxio/avro/SubjectExplorerSpec.scala — mock `SchemaRegistryClient`: `listAll(client, None)` returns `Right` sorted by name with versions; `getAllSubjects` throws ⇒ `Left(DownloadError.SubjectListFailed)`; `getAllVersions` throws ⇒ `Left(DownloadError.SubjectVersionsFetchFailed(subject, _))` (fail-fast, no partial)
+- [x] T008 [P] [US1] Write FAILING integration test it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala — mirror the Testcontainers setup of the sibling `SubjectResolverIntegrationSpec.scala` (package `org.galaxio.avro`); register 2+ subjects in a real registry, `SubjectExplorer.listAll(realClient, None)` returns all sorted with correct version ranges; no HTTP mocking
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Implement src/main/scala/org/galaxio/avro/SubjectExplorer.scala — `object SubjectExplorer { def listAll(client: SchemaRegistryClient, filter: Option[String]): Either[DownloadError, SubjectListing] }`: `getAllSubjects().asScala.toList.sorted` (stdlib `Try(...).toEither.left.map(SubjectListFailed)`); per subject sequentially fetch `getAllVersions(...).asScala.map(_.intValue).toList` (left ⇒ `SubjectVersionsFetchFailed`) accumulating via `foldLeft` short-circuit; best-effort `getCompatibility` → `Option`; apply `filter.fold(listing)(listing.matching)` (makes T007 pass; depends on T002, T005, T006)
+- [x] T010 [US1] Wire the task in src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala — add `schemaRegistryListSubjects = taskKey[Unit](...)` to `autoImport`; add root→`Compile`-scoped delegation; `Compile / schemaRegistryListSubjects` body mirrors existing tasks: `val logger = streams.value.log`; `withRegistryClient(url, cacheSize, auth, properties) { client => SubjectExplorer.listAll(client, None) match { case Left(e) => sys.error(e.message); case Right(listing) => log count + one line per subject (name padded, `versions: <range>`, `compat: <level|(default)>`) } }`
+- [x] T011 [US1] Create scripted e2e src/sbt-test/schema-registry/list-subjects/ mirroring `download-wildcard`: `build.sbt` (`schemaRegistryUrl := RegistryFixture.url`), `project/` fixture wiring (`docker.sbt`/`plugins.sbt`), and `test` script asserting `> schemaRegistryListSubjects` SUCCEEDS; add a bad-URL negative path asserting `-> schemaRegistryListSubjects` FAILS
+
+**Checkpoint**: US1 fully functional — discovery from sbt works and fails cleanly. MVP shippable.
+
+---
+
+## Phase 4: User Story 2 — Filter Subjects by Pattern (Priority: P2)
+
+**Goal**: Setting `schemaRegistrySubjectFilter := Some(text)` restricts the listing to subjects whose name contains `text` (case-insensitive); reported count reflects the filtered set; unset ⇒ all.
+
+**Independent Test**: With several subjects, set the filter to match one group → only those listed and the count matches; unset → all listed; casing ignored.
+
+### Tests for User Story 2 (write first, must FAIL)
+
+- [x] T012 [P] [US2] Add FAILING cases to src/test/scala/org/galaxio/avro/SubjectExplorerSpec.scala — `listAll(client, Some("order"))` keeps only matching (case-insensitive); `Some("")` ⇒ all
+- [x] T013 [P] [US2] Add FAILING filter scenario to it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala — filter narrows the real listing and count reflects it
+
+### Implementation for User Story 2
+
+- [x] T014 [US2] Add `schemaRegistrySubjectFilter = settingKey[Option[String]](...)` to `autoImport` and its default `None` in `defaultSettings` in src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+- [x] T015 [US2] Pass `schemaRegistrySubjectFilter.value` into `SubjectExplorer.listAll(client, _)` in the task body (replacing the hard-coded `None`) so the logged count/lines reflect filtering, in src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala (depends on T010, T014)
+- [x] T016 [US2] Extend src/sbt-test/schema-registry/list-subjects/test — `> set schemaRegistrySubjectFilter := Some("Order")` then `> schemaRegistryListSubjects` SUCCEEDS (filtered run)
+
+**Checkpoint**: US1 + US2 both work independently; filtering narrows results case-insensitively.
+
+---
+
+## Phase 5: User Story 3 — Inspect Versions & Compatibility for Debugging (Priority: P3)
+
+**Goal**: Each subject's entry surfaces its version range and compatibility level; subjects without a subject-level override are shown as `(default)` rather than failing.
+
+**Independent Test**: Register one subject with a subject-level compatibility override and multiple versions, and one without; run the task → first shows its level and range, second shows `(default)`.
+
+### Tests for User Story 3 (write first, must FAIL)
+
+- [x] T017 [P] [US3] Add FAILING cases to src/test/scala/org/galaxio/avro/SubjectExplorerSpec.scala — multi-version subject ⇒ `versionRange == "1..N"`; subject-level compat ⇒ `Some(level)`; `getCompatibility` throws ⇒ `None` (best-effort, task still `Right`)
+- [x] T018 [P] [US3] Add FAILING scenario to it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala — register a subject with a subject-level compatibility override + multiple versions, and one with NO subject-level override; assert the first yields `compatibility == Some(level)` with the correct `versionRange`, and EXPLICITLY assert the override-less subject yields `compatibility == None` (pins research D3: `getCompatibility` returns subject-level only / `None` ⇒ `(default)`, against the real registry)
+
+### Implementation for User Story 3
+
+- [x] T019 [US3] Verify (and adjust only if T010 left a gap) the task's per-subject log line in src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala renders compatibility as the level or `(default)` when `None`, and the version range via `SubjectInfo.versionRange` (single vs `first..last`). NOTE: T010 should already produce this line — this is the US3 acceptance gate; if T010 fully satisfies FR-004/FR-005, this task is a no-op confirmation, not new code (depends on T010)
+
+**Checkpoint**: All three stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+**Purpose**: Docs and full-stack verification.
+
+- [x] T020 [P] Document `schemaRegistryListSubjects` and `schemaRegistrySubjectFilter` (usage + sample output) in README.md (and in AGENTS.md task list if one is maintained)
+- [x] T021 Full verify — `sbt scalafmtAll scalafmtSbt` then `sbt scalafmtCheckAll scalafmtSbtCheck compile test`, `sbt it/test`, `sbt scripted` all green (confirms FR-013 backward compat: existing `download-*`/`register-*` scripted tests still pass)
+- [x] T022 [P] Execute [quickstart.md](quickstart.md) scenarios V1–V6 and confirm each acceptance mapping holds
+
+---
+
+## Dependencies & Execution Order
+
+### Phase order
+- Setup (T001) → Foundational (T002–T006) → US1 (T007–T011) → US2 (T012–T016) → US3 (T017–T019) → Polish (T020–T022)
+- Foundational BLOCKS all stories. After Foundational, stories are independently testable; US2/US3 build on US1's task body (shared `SchemaDownloaderPlugin.scala`), so run in priority order when staffed by one developer.
+
+### Key task dependencies
+- T009 depends on T002, T005, T006
+- T010 depends on T009
+- T015 depends on T010, T014
+- T019 depends on T010
+- T007/T008 (tests) precede T009; T012/T013 precede T014/T015; T017/T018 precede T019
+
+### Same-file serialization (NOT parallel)
+- `SchemaDownloaderPlugin.scala`: T010 → T014 → T015 → T019 (sequential)
+- `SubjectExplorerSpec.scala`: T007 → T012 → T017 (sequential edits)
+- `ListSubjectsIntegrationSpec.scala`: T008 → T013 → T018 (sequential edits)
+
+### Parallel opportunities
+- Foundational: T002, T003, T004 in parallel; then T005, T006 in parallel.
+- US1 tests: T007 ∥ T008 (different files).
+- Polish: T020 ∥ T022.
+
+---
+
+## Parallel Example: Foundational
+
+```bash
+# Different files, no inter-dependency:
+T002  DownloadError.scala  (new error case)
+T003  SubjectInfoSpec.scala (failing test)
+T004  SubjectListingSpec.scala (failing test)
+# then:
+T005  SubjectInfo.scala
+T006  SubjectListing.scala
+```
+
+## Parallel Example: User Story 1 tests
+
+```bash
+T007  SubjectExplorerSpec.scala (unit, mock client)
+T008  ListSubjectsIntegrationSpec.scala (it/, Testcontainers)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+1. Setup (T001) → Foundational (T002–T006) → US1 (T007–T011).
+2. STOP and validate: register subjects, run `sbt schemaRegistryListSubjects`, confirm full sorted listing + clean failure on bad URL.
+3. Ship MVP.
+
+### Incremental delivery
+- + US2 (filter) → validate narrowing → ship.
+- + US3 (versions/compat debugging detail) → validate `(default)` + ranges → ship.
+- Each increment keeps existing scripted tests green (backward compat).
+
+---
+
+## Notes
+- Test-first: confirm each FAILING test fails before its implementation task.
+- No cats — use `Try`/`Either`/`foldLeft`; `scala.collection.JavaConverters` for Java collections (2.12).
+- `-Xfatal-warnings`: no unused imports / warnings.
+- Run `scalafmtAll`/`scalafmtSbt` before any commit (sub-agents too).
+- Commit after each task or logical group; keep commits green and semantic.

--- a/src/main/scala/org/galaxio/avro/BoundedParallel.scala
+++ b/src/main/scala/org/galaxio/avro/BoundedParallel.scala
@@ -1,0 +1,31 @@
+package org.galaxio.avro
+
+import java.util.concurrent.Executors
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+/** Bounded-concurrency `traverse`: apply `f` to every item with at most `parallelism` concurrent evaluations, preserving input
+  * order. Shared by `ParallelDownloader` (per-subject download) and `SubjectExplorer` (per-subject metadata fetch) so the
+  * thread-pool lifecycle lives in one place.
+  */
+object BoundedParallel {
+
+  private val AwaitTimeout = 30.minutes
+
+  /** @param parallelism
+    *   `<= 1` runs sequentially with no thread pool; otherwise a fixed pool sized to `min(parallelism, items.size)` runs the
+    *   work concurrently. The pool is always shut down. Result order matches `items`.
+    */
+  def traverse[A, B](items: List[A], parallelism: Int)(f: A => B): List[B] =
+    if (items.isEmpty) Nil
+    else if (parallelism <= 1) items.map(f)
+    else {
+      val pool = Executors.newFixedThreadPool(math.min(parallelism, items.size))
+      try {
+        implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(pool)
+        Await.result(Future.traverse(items)(a => Future(f(a))), AwaitTimeout)
+      } finally {
+        pool.shutdownNow()
+      }
+    }
+}

--- a/src/main/scala/org/galaxio/avro/DownloadError.scala
+++ b/src/main/scala/org/galaxio/avro/DownloadError.scala
@@ -37,6 +37,11 @@ object DownloadError {
     override val cause: Option[Throwable] = Some(error)
   }
 
+  final case class SubjectVersionsFetchFailed(subject: String, error: Throwable) extends DownloadError {
+    val message: String                   = s"Failed to fetch versions for $subject: ${error.getMessage}"
+    override val cause: Option[Throwable] = Some(error)
+  }
+
   final case class ManifestParseError(error: Throwable) extends DownloadError {
     val message: String                   = s"Failed to parse version manifest: ${error.getMessage}"
     override val cause: Option[Throwable] = Some(error)

--- a/src/main/scala/org/galaxio/avro/ParallelDownloader.scala
+++ b/src/main/scala/org/galaxio/avro/ParallelDownloader.scala
@@ -3,10 +3,7 @@ package org.galaxio.avro
 import sbt.util.Logger
 
 import java.nio.file.Path
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
 
 final class ParallelDownloader private (
     downloader: Downloader,
@@ -17,43 +14,14 @@ final class ParallelDownloader private (
 
   def downloadAll(
       subjects: List[RegistrySubject],
-  ): List[(RegistrySubject, Either[DownloadError, Path])] =
-    if (subjects.isEmpty) List.empty
-    else if (parallelism == 1) downloadSequential(subjects)
-    else downloadParallel(subjects)
-
-  private def downloadSequential(
-      subjects: List[RegistrySubject],
   ): List[(RegistrySubject, Either[DownloadError, Path])] = {
     val total     = subjects.size
     val completed = new AtomicInteger(0)
-    subjects.map { subject =>
+    BoundedParallel.traverse(subjects, parallelism) { subject =>
       val result = retryPolicy.execute(downloader.schemaSubjectToFile(subject), subject.name, logger)
       val n      = completed.incrementAndGet()
       logProgress(subject.name, n, total, result)
       subject -> result
-    }
-  }
-
-  private def downloadParallel(
-      subjects: List[RegistrySubject],
-  ): List[(RegistrySubject, Either[DownloadError, Path])] = {
-    val total     = subjects.size
-    val completed = new AtomicInteger(0)
-    val pool      = Executors.newFixedThreadPool(parallelism)
-    try {
-      implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(pool)
-      val futures                       = subjects.map { subject =>
-        Future {
-          val result = retryPolicy.execute(downloader.schemaSubjectToFile(subject), subject.name, logger)
-          val n      = completed.incrementAndGet()
-          logProgress(subject.name, n, total, result)
-          subject -> result
-        }
-      }
-      Await.result(Future.sequence(futures), 30.minutes)
-    } finally {
-      pool.shutdownNow()
     }
   }
 

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -32,6 +32,9 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       settingKey[Int]("Maximum retry attempts for transient download failures (0 = no retry)")
     val schemaRegistryResolveReferences =
       settingKey[Boolean]("Auto-download schemas referenced by downloaded schemas (transitive)")
+    val schemaRegistryListSubjects      = taskKey[Unit]("List subjects in the schema registry")
+    val schemaRegistrySubjectFilter     =
+      settingKey[Option[String]]("Optional case-insensitive substring filter for schemaRegistryListSubjects")
 
     lazy val defaultSettings: Seq[Setting[?]] = Seq(
       schemaRegistryUrl               := "http://localhost:8081",
@@ -46,6 +49,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       schemaRegistryParallelism       := 4,
       schemaRegistryRetries           := 3,
       schemaRegistryResolveReferences := true,
+      schemaRegistrySubjectFilter     := None,
     )
   }
 
@@ -258,6 +262,35 @@ object SchemaDownloaderPlugin extends AutoPlugin {
 
           if (!report.isSuccess)
             sys.error(s"${report.incompatible.size} incompatible, ${report.failed.size} failed")
+        }
+      }
+    },
+    schemaRegistryListSubjects                := (Compile / schemaRegistryListSubjects).value,
+    Compile / schemaRegistryListSubjects      := {
+      val logger      = streams.value.log
+      val filter      = schemaRegistrySubjectFilter.value
+      val parallelism = schemaRegistryParallelism.value
+
+      if (parallelism < 1 || parallelism > ParallelDownloader.MaxParallelism)
+        sys.error(DownloadError.InvalidParallelism(parallelism).message)
+
+      withRegistryClient(
+        schemaRegistryUrl.value,
+        schemaRegistryCacheSize.value,
+        schemaRegistryAuth.value,
+        schemaRegistryProperties.value,
+      ) { client =>
+        SubjectExplorer.listAll(client, filter, parallelism) match {
+          case Left(err)      =>
+            err.cause.foreach(logger.trace(_))
+            sys.error(err.message)
+          case Right(listing) =>
+            logger.info(s"Found ${listing.size} subject(s):")
+            val width = listing.subjects.map(_.name.length).foldLeft(0)(_ max _)
+            listing.subjects.foreach { info =>
+              val compat = info.compatibility.getOrElse("(default)")
+              logger.info(s"  ${info.name.padTo(width, ' ')}  (versions: ${info.versionRange}, compat: $compat)")
+            }
         }
       }
     },

--- a/src/main/scala/org/galaxio/avro/SubjectExplorer.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectExplorer.scala
@@ -1,0 +1,68 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/** Pure core for the list-subjects task: fetch + transform, no logging or side effects beyond the injected client. Presentation
+  * lives in `SchemaDownloaderPlugin`.
+  */
+object SubjectExplorer {
+
+  /** @param parallelism
+    *   number of concurrent per-subject fetches (1 = sequential). Reuses the plugin's `schemaRegistryParallelism` budget.
+    */
+  def listAll(
+      client: SchemaRegistryClient,
+      filter: Option[String],
+      parallelism: Int = 1,
+  ): Either[DownloadError, SubjectListing] =
+    for {
+      names <- Try(client.getAllSubjects.asScala.toList.sorted).toEither.left
+                 .map(DownloadError.SubjectListFailed)
+      // Filter by name BEFORE per-subject fetch: avoids fetching versions/compatibility for subjects
+      // the user excluded, and scopes fail-fast to the subjects actually requested.
+      infos <- fetchInfos(client, filterNames(names, filter), parallelism)
+    } yield SubjectListing(infos)
+
+  // Empty/absent filter keeps all; otherwise the shared case-insensitive substring predicate.
+  private def filterNames(names: List[String], filter: Option[String]): List[String] =
+    filter.fold(names)(f => names.filter(SubjectListing.nameMatches(_, f)))
+
+  // Fetch each kept subject (bounded concurrency), then fail-fast: the first Left (in subject order) wins.
+  // The Try guards the parallel path so the core never throws (e.g. an Await timeout/interrupt) — FR-010.
+  private def fetchInfos(
+      client: SchemaRegistryClient,
+      names: List[String],
+      parallelism: Int,
+  ): Either[DownloadError, List[SubjectInfo]] =
+    Try(BoundedParallel.traverse(names, parallelism)(fetchInfo(client, _))).toEither.left
+      .map(DownloadError.SubjectListFailed)
+      .flatMap(firstError)
+
+  // Single pass: accumulate in order, short-circuit to the FIRST Left (subject order).
+  private def firstError(
+      results: List[Either[DownloadError, SubjectInfo]],
+  ): Either[DownloadError, List[SubjectInfo]] =
+    results
+      .foldLeft(Right(Nil): Either[DownloadError, List[SubjectInfo]]) { (acc, e) =>
+        for {
+          xs <- acc
+          x  <- e
+        } yield x :: xs
+      }
+      .map(_.reverse)
+
+  private def fetchInfo(
+      client: SchemaRegistryClient,
+      subject: String,
+  ): Either[DownloadError, SubjectInfo] =
+    Try(client.getAllVersions(subject).asScala.map(_.intValue).toList.sorted).toEither.left
+      .map(e => DownloadError.SubjectVersionsFetchFailed(subject, e))
+      .map { versions =>
+        // Best-effort: a missing or unreadable subject-level compatibility is reported as None.
+        val compat = Try(Option(client.getCompatibility(subject))).toOption.flatten
+        SubjectInfo(subject, versions, compat)
+      }
+}

--- a/src/main/scala/org/galaxio/avro/SubjectInfo.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectInfo.scala
@@ -1,0 +1,15 @@
+package org.galaxio.avro
+
+final case class SubjectInfo(
+    name: String,
+    versions: List[Int],
+    compatibility: Option[String],
+) {
+  def latestVersion: Option[Int] = versions.lastOption
+
+  def versionRange: String = versions match {
+    case Nil      => "none"
+    case v :: Nil => v.toString
+    case _        => s"${versions.head}..${versions.last}"
+  }
+}

--- a/src/main/scala/org/galaxio/avro/SubjectListing.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectListing.scala
@@ -1,0 +1,18 @@
+package org.galaxio.avro
+
+final case class SubjectListing(subjects: List[SubjectInfo]) {
+  def size: Int = subjects.size
+
+  /** Keep subjects whose name matches `filter` (case-insensitive substring). Empty filter matches all. */
+  def matching(filter: String): SubjectListing =
+    copy(subjects = subjects.filter(s => SubjectListing.nameMatches(s.name, filter)))
+}
+
+object SubjectListing {
+
+  /** The one definition of the list-subjects filter predicate: case-insensitive substring on the subject name. Used both for
+    * pre-fetch name filtering (`SubjectExplorer`) and post-fetch listing filtering (`matching`).
+    */
+  def nameMatches(name: String, filter: String): Boolean =
+    name.toLowerCase.contains(filter.toLowerCase)
+}

--- a/src/sbt-test/schema-registry/list-subjects/build.sbt
+++ b/src/sbt-test/schema-registry/list-subjects/build.sbt
@@ -1,0 +1,5 @@
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion      := "2.12.21",
+    schemaRegistryUrl := RegistryFixture.url,
+  )

--- a/src/sbt-test/schema-registry/list-subjects/project/RegistryFixture.scala
+++ b/src/sbt-test/schema-registry/list-subjects/project/RegistryFixture.scala
@@ -1,0 +1,1 @@
+../../.fixtures/RegistryFixture.scala

--- a/src/sbt-test/schema-registry/list-subjects/project/plugins.sbt
+++ b/src/sbt-test/schema-registry/list-subjects/project/plugins.sbt
@@ -1,0 +1,1 @@
+../../.fixtures/docker.sbt

--- a/src/sbt-test/schema-registry/list-subjects/test
+++ b/src/sbt-test/schema-registry/list-subjects/test
@@ -1,0 +1,10 @@
+# List subjects against the fixture registry — task must succeed and see both subjects.
+> schemaRegistryListSubjects
+
+# Filtered listing (case-insensitive substring on "order") — must also succeed.
+> set schemaRegistrySubjectFilter := Some("order")
+> schemaRegistryListSubjects
+
+# Unreachable registry — task must fail with a clear error.
+> set schemaRegistryUrl := "http://127.0.0.1:1"
+-> schemaRegistryListSubjects

--- a/src/test/scala/org/galaxio/avro/BoundedParallelSpec.scala
+++ b/src/test/scala/org/galaxio/avro/BoundedParallelSpec.scala
@@ -1,0 +1,39 @@
+package org.galaxio.avro
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class BoundedParallelSpec extends AnyFlatSpec with Matchers {
+
+  "BoundedParallel.traverse" should "return Nil for empty input" in {
+    BoundedParallel.traverse(List.empty[Int], 4)(_ * 2) shouldBe Nil
+  }
+
+  it should "preserve input order when sequential" in {
+    BoundedParallel.traverse(List(1, 2, 3, 4), 1)(_ * 2) shouldBe List(2, 4, 6, 8)
+  }
+
+  it should "preserve input order when parallel" in {
+    BoundedParallel.traverse((1 to 20).toList, 4)(_ + 1) shouldBe (2 to 21).toList
+  }
+
+  it should "apply f to every element exactly once when parallel" in {
+    val seen = java.util.concurrent.ConcurrentHashMap.newKeySet[Int]()
+    val out  = BoundedParallel.traverse((1 to 50).toList, 8) { i => seen.add(i); i }
+    out shouldBe (1 to 50).toList
+    seen.size shouldBe 50
+  }
+
+  it should "treat parallelism <= 1 as sequential without error" in {
+    BoundedParallel.traverse(List(1, 2, 3), 0)(_ + 10) shouldBe List(11, 12, 13)
+  }
+
+  it should "actually run elements concurrently when parallelism > 1" in {
+    // 4 tasks each sleeping 200ms on a pool of 4 finish well under the 800ms sequential sum.
+    val start   = System.nanoTime()
+    val results = BoundedParallel.traverse(List(1, 2, 3, 4), 4) { i => Thread.sleep(200); i }
+    val elapsed = (System.nanoTime() - start) / 1000000
+    results shouldBe List(1, 2, 3, 4)
+    elapsed should be < 700L
+  }
+}

--- a/src/test/scala/org/galaxio/avro/SubjectExplorerSpec.scala
+++ b/src/test/scala/org/galaxio/avro/SubjectExplorerSpec.scala
@@ -1,0 +1,148 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.{Arrays => JArrays}
+
+class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  private def jints(vs: Int*): java.util.List[Integer] =
+    JArrays.asList(vs.map(Integer.valueOf): _*)
+
+  // Subjects each with a single version and no subject-level compatibility override.
+  private def clientWith(names: String*): SchemaRegistryClient = {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList(names: _*))
+    names.foreach { n =>
+      when(client.getAllVersions(n)).thenReturn(jints(1))
+      when(client.getCompatibility(n)).thenThrow(new RuntimeException("40401"))
+    }
+    client
+  }
+
+  // --- US1: discover all ---
+
+  "SubjectExplorer.listAll" should "return all subjects sorted by name" in {
+    val client = clientWith("user-value", "order-value", "payment-value")
+    val result = SubjectExplorer.listAll(client, None)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.subjects.map(_.name) shouldBe List("order-value", "payment-value", "user-value")
+  }
+
+  it should "extract the version list for each subject" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList("a-value"))
+    when(client.getAllVersions("a-value")).thenReturn(jints(1, 2, 3))
+    when(client.getCompatibility("a-value")).thenThrow(new RuntimeException("40401"))
+
+    val info = SubjectExplorer.listAll(client, None).right.get.subjects.head
+    info.versions shouldBe List(1, 2, 3)
+    info.versionRange shouldBe "1..3"
+  }
+
+  it should "return Left(SubjectListFailed) when getAllSubjects throws" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenThrow(new RuntimeException("connection refused"))
+
+    val result = SubjectExplorer.listAll(client, None)
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.SubjectListFailed]
+  }
+
+  it should "fail-fast with SubjectVersionsFetchFailed naming the subject whose versions cannot be fetched" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList("ok-value", "bad-value"))
+    when(client.getAllVersions("ok-value")).thenReturn(jints(1))
+    when(client.getCompatibility("ok-value")).thenThrow(new RuntimeException("40401"))
+    when(client.getAllVersions("bad-value")).thenThrow(new RuntimeException("gone"))
+
+    val result = SubjectExplorer.listAll(client, None)
+    result shouldBe a[Left[_, _]]
+    val err    = result.left.get
+    err shouldBe a[DownloadError.SubjectVersionsFetchFailed]
+    err.asInstanceOf[DownloadError.SubjectVersionsFetchFailed].subject shouldBe "bad-value"
+  }
+
+  // --- US2: filter ---
+
+  it should "filter case-insensitively by substring" in {
+    val client = clientWith("user-value", "order-value", "payment-value")
+    SubjectExplorer.listAll(client, Some("ORDER")).right.get.subjects.map(_.name) shouldBe List("order-value")
+  }
+
+  it should "treat an empty filter as 'list all'" in {
+    val client = clientWith("user-value", "order-value")
+    SubjectExplorer.listAll(client, Some("")).right.get.size shouldBe 2
+  }
+
+  it should "not fetch or fail on subjects excluded by the filter" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList("order-value", "broken-value"))
+    when(client.getAllVersions("order-value")).thenReturn(jints(1))
+    when(client.getCompatibility("order-value")).thenThrow(new RuntimeException("40401"))
+    // broken-value would fail if fetched, but the filter excludes it before any per-subject call.
+    when(client.getAllVersions("broken-value")).thenThrow(new RuntimeException("gone"))
+
+    val result = SubjectExplorer.listAll(client, Some("order"))
+    result shouldBe a[Right[_, _]]
+    result.right.get.subjects.map(_.name) shouldBe List("order-value")
+    verify(client, org.mockito.Mockito.never()).getAllVersions("broken-value")
+  }
+
+  // --- Parallel fetch (reuses schemaRegistryParallelism) ---
+
+  it should "produce the same sorted result with parallelism > 1" in {
+    val client = clientWith("user-value", "order-value", "payment-value")
+    SubjectExplorer.listAll(client, None, parallelism = 4).right.get.subjects.map(_.name) shouldBe
+      List("order-value", "payment-value", "user-value")
+  }
+
+  it should "fail-fast in parallel mode when a subject's versions cannot be fetched" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList("ok-value", "bad-value"))
+    when(client.getAllVersions("ok-value")).thenReturn(jints(1))
+    when(client.getCompatibility("ok-value")).thenThrow(new RuntimeException("40401"))
+    when(client.getAllVersions("bad-value")).thenThrow(new RuntimeException("gone"))
+
+    val result = SubjectExplorer.listAll(client, None, parallelism = 4)
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldBe a[DownloadError.SubjectVersionsFetchFailed]
+  }
+
+  it should "report the first failing subject in sorted order when several fail (parallel)" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList("z-bad", "a-bad"))
+    when(client.getAllVersions("a-bad")).thenThrow(new RuntimeException("a fail"))
+    when(client.getAllVersions("z-bad")).thenThrow(new RuntimeException("z fail"))
+
+    val result = SubjectExplorer.listAll(client, None, parallelism = 4)
+    result shouldBe a[Left[_, _]]
+    result.left.get.asInstanceOf[DownloadError.SubjectVersionsFetchFailed].subject shouldBe "a-bad"
+  }
+
+  // --- US3: versions + compatibility (debugging) ---
+
+  it should "surface a subject-level compatibility level" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList("c-value"))
+    when(client.getAllVersions("c-value")).thenReturn(jints(1))
+    when(client.getCompatibility("c-value")).thenReturn("BACKWARD")
+
+    SubjectExplorer.listAll(client, None).right.get.subjects.head.compatibility shouldBe Some("BACKWARD")
+  }
+
+  it should "report None compatibility (best-effort) when getCompatibility throws, without failing the task" in {
+    val client = mock[SchemaRegistryClient]
+    when(client.getAllSubjects).thenReturn(JArrays.asList("c-value"))
+    when(client.getAllVersions("c-value")).thenReturn(jints(1))
+    when(client.getCompatibility("c-value")).thenThrow(new RuntimeException("40401"))
+
+    val result = SubjectExplorer.listAll(client, None)
+    result shouldBe a[Right[_, _]]
+    result.right.get.subjects.head.compatibility shouldBe None
+  }
+}

--- a/src/test/scala/org/galaxio/avro/SubjectInfoSpec.scala
+++ b/src/test/scala/org/galaxio/avro/SubjectInfoSpec.scala
@@ -1,0 +1,27 @@
+package org.galaxio.avro
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SubjectInfoSpec extends AnyFlatSpec with Matchers {
+
+  "SubjectInfo.versionRange" should "be 'none' when there are no versions" in {
+    SubjectInfo("s", Nil, None).versionRange shouldBe "none"
+  }
+
+  it should "be the single value when only one version exists" in {
+    SubjectInfo("s", List(3), None).versionRange shouldBe "3"
+  }
+
+  it should "be 'first..last' for multiple versions" in {
+    SubjectInfo("s", List(1, 2, 3, 4, 5), None).versionRange shouldBe "1..5"
+  }
+
+  "SubjectInfo.latestVersion" should "be the last version" in {
+    SubjectInfo("s", List(1, 2, 5), None).latestVersion shouldBe Some(5)
+  }
+
+  it should "be None when there are no versions" in {
+    SubjectInfo("s", Nil, None).latestVersion shouldBe None
+  }
+}

--- a/src/test/scala/org/galaxio/avro/SubjectListingSpec.scala
+++ b/src/test/scala/org/galaxio/avro/SubjectListingSpec.scala
@@ -1,0 +1,32 @@
+package org.galaxio.avro
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SubjectListingSpec extends AnyFlatSpec with Matchers {
+
+  private def info(name: String): SubjectInfo = SubjectInfo(name, List(1), None)
+
+  private val listing =
+    SubjectListing(List(info("user-value"), info("order-value"), info("payment-value")))
+
+  "SubjectListing.matching" should "keep case-insensitive substring matches" in {
+    listing.matching("ORDER").subjects.map(_.name) shouldBe List("order-value")
+  }
+
+  it should "match a substring appearing anywhere in the name" in {
+    listing.matching("value").subjects should have size 3
+  }
+
+  it should "return all subjects for an empty filter" in {
+    listing.matching("").subjects should have size 3
+  }
+
+  it should "return empty when nothing matches" in {
+    listing.matching("nope").subjects shouldBe empty
+  }
+
+  "SubjectListing.size" should "report the number of subjects" in {
+    listing.size shouldBe 3
+  }
+}


### PR DESCRIPTION
Closes #32.

## What

A new `schemaRegistryListSubjects` sbt task that lists registry subjects — each with its **version range** and **compatibility level** — directly from sbt, for discovery and debugging (no `curl`, no separate UI). Reuses the existing connection settings; fully additive and backward-compatible.

```bash
sbt schemaRegistryListSubjects
# [info] Found 42 subject(s):
# [info]   user-value    (versions: 1..5, compat: BACKWARD)
# [info]   order-value   (versions: 1..3, compat: (default))

sbt 'set schemaRegistrySubjectFilter := Some("order")' schemaRegistryListSubjects
```

## Why

Discovering what exists in the registry while configuring downloads currently means reaching for `curl http://localhost:8081/subjects` or a UI tool. This brings it into the build.

## Design

- **Pure core** `SubjectExplorer.listAll(client, filter, parallelism): Either[DownloadError, SubjectListing]` — fetch + transform, no logging, never throws (FR-010). Presentation (formatting/logging, `sys.error`) lives only in the sbt task, matching the existing download/register tasks.
- **New value types** `SubjectInfo` (name, versions, compatibility; derived `versionRange`/`latestVersion`) and `SubjectListing`.
- **Error model** reuses `DownloadError`: existing `SubjectListFailed` for the subject-list call, new `SubjectVersionsFetchFailed` per subject. (The issue sketched `RegistryError.FetchFailed`, which does not exist — `DownloadError` is the correct existing model.)
- **Filter** — new `schemaRegistrySubjectFilter: Option[String]`, case-insensitive substring (default `None` = list all). Distinct from the regex `schemaRegistrySubjectPatterns` used by downloads.
- **Fail-fast** — a subject-list or per-subject versions failure fails the task with a clear message; the filter is applied **before** per-subject fetch, so excluded subjects are never fetched and cannot fail the task.
- **Compatibility is best-effort** — a missing/unreadable subject-level override is shown as `(default)`, never fails the task.
- **Concurrency** — per-subject metadata is fetched concurrently, reusing the existing `schemaRegistryParallelism` budget (1 = sequential, max 32). The thread-pool/`Future`/`Await`/shutdown pattern was extracted into a shared `BoundedParallel.traverse` and `ParallelDownloader` was refactored to use it too — reuse instead of duplication.

## Tests

- **Unit** (mockito-scala): `SubjectExplorerSpec`, `SubjectInfoSpec`, `SubjectListingSpec`, `BoundedParallelSpec` — data extraction, sort, filter, fail-fast (incl. first-error-in-order under parallelism), best-effort compat, bounded concurrency.
- **Integration** (Testcontainers, real Schema Registry): `SubjectExplorerIntegrationSpec` — multi-version range, compat override vs `(default)`, filter, and parallel == sequential parity.
- **Scripted e2e**: `src/sbt-test/schema-registry/list-subjects/` — success, filtered, and unreachable-registry failure.

Local: `scalafmtCheckAll scalafmtSbtCheck compile test` (169 unit), `it/test` (54), and scripted all green; existing `download-*`/`register-*` scripted tests unaffected (backward compat).

## Reviewer notes

- Plan/spec artifacts under `specs/008-list-subjects-task/` (Spec Kit workflow).
- `ParallelDownloader` was refactored (public API unchanged) to share `BoundedParallel`; its existing unit + integration tests confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)