### PR TITLE
Polish: post-feature cleanup, correctness fix, and test hardening

### DIFF
--- a/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
@@ -1,53 +1,13 @@
 package org.galaxio.avro
 
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 
 import java.io.File
 import java.nio.file.Files
-import scala.util.Try
 
-class CompatibilityCheckerIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
-
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
-
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-  }
-
-  override def afterAll(): Unit = {
-    Option(registryClient).foreach(c => Try(c.close()))
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
+class CompatibilityCheckerIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
   private def tempSchemaFile(content: String, suffix: String = ".avsc"): File = {
     val f = File.createTempFile("compat-it-", suffix)

--- a/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
@@ -81,7 +81,10 @@ class CompatibilityCheckerIntegrationSpec extends AnyFlatSpec with Matchers with
     val result = CompatibilityChecker.checkOne(registryClient, RegistryRegistration("compat-check-fail", file))
     result shouldBe a[CompatibilityResult.Incompatible]
     val incompatible = result.asInstanceOf[CompatibilityResult.Incompatible]
+    incompatible.subject shouldBe "compat-check-fail"
     incompatible.messages should not be empty
+    // The break is a new required field with no default — the verbose verdict must say so.
+    incompatible.messages.exists(_.toLowerCase.contains("default")) shouldBe true
   }
 
   it should "return Compatible for a brand-new subject with no prior versions" in {
@@ -166,6 +169,11 @@ class CompatibilityCheckerIntegrationSpec extends AnyFlatSpec with Matchers with
 
     report.compatible should have size 1
     report.incompatible should have size 1
+    report.failed shouldBe empty
+    // Counts alone don't prove WHICH registration landed where, nor that the verdict carries detail.
+    report.compatible.head.subject shouldBe "compat-batch"
+    report.incompatible.head.subject shouldBe "compat-batch"
+    report.incompatible.head.messages should not be empty
     report.isSuccess shouldBe false
   }
 }

--- a/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/CompatibilityCheckerIntegrationSpec.scala
@@ -95,20 +95,9 @@ class CompatibilityCheckerIntegrationSpec extends AnyFlatSpec with Matchers with
     result shouldBe CompatibilityResult.Compatible("compat-new-subject")
   }
 
-  it should "return Failed for invalid schema content" in {
-    val file   = tempSchemaFile("not valid json at all")
-    val result = CompatibilityChecker.checkOne(registryClient, RegistryRegistration("compat-invalid", file))
-    result shouldBe a[CompatibilityResult.Failed]
-  }
-
-  it should "return Failed for missing file" in {
-    val result = CompatibilityChecker.checkOne(
-      registryClient,
-      RegistryRegistration("compat-missing", new File("/nonexistent.avsc")),
-    )
-    result shouldBe a[CompatibilityResult.Failed]
-    result.asInstanceOf[CompatibilityResult.Failed].cause shouldBe a[RegistryError.FileNotFound]
-  }
+  // Pure parse-failure / missing-file paths fail before any registry call — owned by
+  // CompatibilityCheckerSpec ("return Failed when schema content is invalid" / "...when file does
+  // not exist"). Removed from the IT layer to avoid duplicating registry-free logic.
 
   it should "return Compatible for backward-compatible Protobuf change" in {
     val v1 =

--- a/it/src/test/scala/org/galaxio/avro/ConcurrencyProbe.scala
+++ b/it/src/test/scala/org/galaxio/avro/ConcurrencyProbe.scala
@@ -20,7 +20,11 @@ object ConcurrencyProbe {
   final case class Probe(client: SchemaRegistryClient, maxConcurrent: AtomicInteger)
 
   /** @param delegate     the real client to forward to
-    * @param parallelism  expected simultaneous in-flight gated calls (latch size)
+    * @param parallelism  expected simultaneous in-flight gated calls — i.e. the latch size. It MUST
+    *                     equal the number of gated calls the test triggers concurrently. If fewer
+    *                     gated calls occur, each parks for up to 10s before `await` returns false and
+    *                     [[Probe.maxConcurrent]] stays below `parallelism` — surfacing as an assertion
+    *                     failure, never an indefinite hang.
     * @param gatedMethods method names that should park on the barrier (e.g. "getLatestSchemaMetadata")
     */
   def gating(delegate: SchemaRegistryClient, parallelism: Int, gatedMethods: Set[String]): Probe = {

--- a/it/src/test/scala/org/galaxio/avro/ConcurrencyProbe.scala
+++ b/it/src/test/scala/org/galaxio/avro/ConcurrencyProbe.scala
@@ -1,0 +1,50 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+/** Wraps a live [[SchemaRegistryClient]] so selected methods park on a shared barrier, letting an
+  * integration test prove that downloads actually run in parallel rather than just asserting result
+  * counts (which a sequential run satisfies identically).
+  *
+  * Each gated call increments a live-count, records the high-water mark, counts down a latch sized
+  * to `parallelism`, then waits for the latch to reach zero. If execution were sequential the first
+  * gated call would never see the latch reach zero and would time out, so [[maxConcurrent]] stays
+  * below `parallelism` and the test fails.
+  */
+object ConcurrencyProbe {
+
+  final case class Probe(client: SchemaRegistryClient, maxConcurrent: AtomicInteger)
+
+  /** @param delegate     the real client to forward to
+    * @param parallelism  expected simultaneous in-flight gated calls (latch size)
+    * @param gatedMethods method names that should park on the barrier (e.g. "getLatestSchemaMetadata")
+    */
+  def gating(delegate: SchemaRegistryClient, parallelism: Int, gatedMethods: Set[String]): Probe = {
+    val latch       = new CountDownLatch(parallelism)
+    val current     = new AtomicInteger(0)
+    val maxObserved = new AtomicInteger(0)
+
+    val handler = new InvocationHandler {
+      override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
+        if (gatedMethods.contains(method.getName)) {
+          val running = current.incrementAndGet()
+          maxObserved.getAndUpdate(prev => math.max(prev, running))
+          latch.countDown()
+          latch.await(10, TimeUnit.SECONDS)
+          current.decrementAndGet()
+        }
+        method.invoke(delegate, (if (args == null) Array.empty[AnyRef] else args): _*)
+      }
+    }
+
+    val proxy = Proxy
+      .newProxyInstance(getClass.getClassLoader, Array(classOf[SchemaRegistryClient]), handler)
+      .asInstanceOf[SchemaRegistryClient]
+
+    Probe(proxy, maxObserved)
+  }
+}

--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -1,55 +1,16 @@
 package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.entities.{SchemaReference => ConfluentSchemaReference}
 import org.apache.avro.Schema
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import java.util.Collections
-import scala.util.Try
 
-class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
-
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
-
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-  }
-
-  override def afterAll(): Unit = {
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
+class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
   private def avroSchema(json: String): AvroSchema =
     new AvroSchema(new Schema.Parser().parse(json))

--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -136,8 +136,11 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
         val r2 = d2.schemaSubjectToFile(RegistrySubject(subject, 1))
 
         (r1, r2) match {
-          case (Right(p1), Right(p2)) => readFile(p1) shouldBe readFile(p2)
-          case _                      => fail("Both downloads should succeed")
+          case (Right(p1), Right(p2)) =>
+            // Equal AND correct — mutual equality alone would pass if both were identically wrong.
+            readFile(p1) shouldBe schemaJson
+            readFile(p2) shouldBe schemaJson
+          case _ => fail("Both downloads should succeed")
         }
       }
     }
@@ -223,6 +226,12 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
       val file = dir.resolve(s"$mainSubject-1.avsc")
       Files.exists(file) shouldBe true
       readFile(file) shouldBe mainJson
+
+      // The referencing subject must actually carry its reference (would pass even if refs were dropped otherwise).
+      val mainRefs = registryClient.getLatestSchemaMetadata(mainSubject).getReferences
+      mainRefs.size shouldBe 1
+      mainRefs.get(0).getSubject shouldBe baseSubject
+      mainRefs.get(0).getVersion.intValue shouldBe 1
     }
   }
 
@@ -281,6 +290,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     result shouldBe a[Right[_, _]]
     val file   = dir.resolve(s"$subject-1.proto")
     Files.exists(file) shouldBe true
+    readFile(file) should include("message DlProto") // body, not just the filename
   }
 
   it should "download JSON Schema with .json extension" in withFixture { (dir, downloader) =>
@@ -298,6 +308,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     result shouldBe a[Right[_, _]]
     val file   = dir.resolve(s"$subject-1.json")
     Files.exists(file) shouldBe true
+    readFile(file) should include("\"id\"") // body, not just the filename
   }
 
   it should "download mixed schema types with correct extensions" in withFixture { (dir, downloader) =>
@@ -330,5 +341,10 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAnd
     Files.exists(dir.resolve(s"$avroSubject-1.avsc")) shouldBe true
     Files.exists(dir.resolve(s"$protoSubject-1.proto")) shouldBe true
     Files.exists(dir.resolve(s"$jsonSubject-1.json")) shouldBe true
+
+    // Each file holds the right body, not just the right extension.
+    readFile(dir.resolve(s"$avroSubject-1.avsc")) shouldBe avroJson
+    readFile(dir.resolve(s"$protoSubject-1.proto")) should include("MixProto")
+    readFile(dir.resolve(s"$jsonSubject-1.json")) should include("\"v\"")
   }
 }

--- a/it/src/test/scala/org/galaxio/avro/IncrementalDownloadIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/IncrementalDownloadIntegrationSpec.scala
@@ -3,52 +3,14 @@ package org.galaxio.avro
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import org.apache.avro.Schema
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import scala.util.Try
 
-class IncrementalDownloadIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
-
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
-
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-  }
-
-  override def afterAll(): Unit = {
-    Option(registryClient).foreach(c => Try(c.close()))
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
+class IncrementalDownloadIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
   private def avroSchema(json: String): AvroSchema =
     new AvroSchema(new Schema.Parser().parse(json))

--- a/it/src/test/scala/org/galaxio/avro/IncrementalDownloadIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/IncrementalDownloadIntegrationSpec.scala
@@ -101,9 +101,13 @@ class IncrementalDownloadIntegrationSpec extends AnyFlatSpec with Matchers with 
 
       val downloader = Downloader.withExternalClient(registryClient, outputDir, silentLogger)
       val downloaded = decisions.collect { case d @ DownloadDecision.Download(subject, _, _) =>
-        downloader.schemaSubjectToFile(subject)
+        downloader.schemaSubjectToFile(subject) shouldBe a[Right[_, _]]
         subject.name -> d.resolvedVersion.get
       }
+
+      // The download actually wrote both files (its Either was previously discarded).
+      Files.exists(outputDir.resolve(s"$orderSubject-1.avsc")) shouldBe true
+      Files.exists(outputDir.resolve(s"$userSubject-1.avsc")) shouldBe true
 
       val newManifest = IncrementalResolver.updatedManifest(manifest, downloaded)
       newManifest.versions should have size 2

--- a/it/src/test/scala/org/galaxio/avro/IncrementalDownloadIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/IncrementalDownloadIntegrationSpec.scala
@@ -115,27 +115,9 @@ class IncrementalDownloadIntegrationSpec extends AnyFlatSpec with Matchers with 
       newManifest.versionOf(userSubject) shouldBe Some(1)
   }
 
-  it should "skip all subjects when versions unchanged" in {
-    val orderSubject = "incr.test.Order"
-    val userSubject  = "incr.test.User"
-
-    val manifest = VersionManifest(Map(orderSubject -> 1, userSubject -> 1))
-    val subjects = List(
-      RegistrySubject.Latest(orderSubject),
-      RegistrySubject.Latest(userSubject),
-    )
-
-    val decisions = IncrementalResolver.plan(
-      manifest,
-      subjects,
-      s =>
-        Try(registryClient.getLatestSchemaMetadata(s).getVersion: Int).toEither.left
-          .map(DownloadError.SchemaFetchFailed(s, _)),
-    )
-
-    decisions.collect { case s: DownloadDecision.Skip     => s } should have size 2
-    decisions.collect { case d: DownloadDecision.Download => d } shouldBe empty
-  }
+  // "skip all when unchanged" is pure plan logic (owned by IncrementalResolverSpec "skip Latest
+  // subject when manifest version matches registry") and was also order-coupled to the first
+  // scenario's registrations. The live version-match path is exercised by the cache-bypass test below.
 
   it should "download only changed subject after new version registered" in {
     val orderSubject = "incr.test.Order"
@@ -171,30 +153,7 @@ class IncrementalDownloadIntegrationSpec extends AnyFlatSpec with Matchers with 
     } finally freshClient.close()
   }
 
-  it should "download all subjects when manifest is empty (simulating sbt clean)" in {
-    val orderSubject = "incr.test.Order"
-    val userSubject  = "incr.test.User"
-
-    val subjects = List(
-      RegistrySubject.Latest(orderSubject),
-      RegistrySubject.Latest(userSubject),
-    )
-
-    val decisions = IncrementalResolver.plan(
-      VersionManifest.empty,
-      subjects,
-      s =>
-        Try(registryClient.getLatestSchemaMetadata(s).getVersion: Int).toEither.left
-          .map(DownloadError.SchemaFetchFailed(s, _)),
-    )
-
-    decisions.collect { case d: DownloadDecision.Download => d } should have size 2
-  }
-
-  "VersionManifest" should "survive JSON round-trip with real data" in {
-    val manifest = VersionManifest(Map("incr.test.Order" -> 2, "incr.test.User" -> 1))
-    val json     = manifest.toJson
-    val parsed   = VersionManifest.fromJson(json)
-    parsed shouldBe Right(manifest)
-  }
+  // "download all when manifest empty" duplicates the first-run scenario above and
+  // IncrementalResolverSpec ("download all subjects when manifest is empty"); the JSON round-trip is
+  // pure and owned by VersionManifestSpec. Both removed as registry-free duplicates.
 }

--- a/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
@@ -96,12 +96,15 @@ class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with B
     val pd      = ParallelDownloader(downloader, parallelism = 2, noRetry, silentLogger)
     val results = pd.downloadAll(subjects)
 
-    results should have size 3
-    results.count(_._2.isRight) shouldBe 2
-    results.count(_._2.isLeft) shouldBe 1
+    val bySubject = results.map { case (s, r) => s.name -> r }.toMap
+    bySubject("nonexistent-subject") shouldBe a[Left[_, _]]
+    bySubject("nonexistent-subject").left.get shouldBe a[DownloadError.SchemaFetchFailed]
+    bySubject("test-subject-1") shouldBe a[Right[_, _]]
+    bySubject("test-subject-3") shouldBe a[Right[_, _]]
 
-    val files = outDir.toFile.listFiles()
-    files should have length 2
+    // Exactly the two good subjects landed on disk — the failed one wrote nothing.
+    outDir.toFile.listFiles().map(_.getName).toSet shouldBe
+      Set("test-subject-1-1.avsc", "test-subject-3-1.avsc")
   }
 
   it should "download sequentially with parallelism 1" in {
@@ -139,8 +142,13 @@ class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with B
     results should have size 5
     results.count(_._2.isRight) shouldBe 5
 
-    val downloaded = results.collect { case (s, Right(_)) => s.name -> 1 }
+    // Build the manifest from the REAL registry version, not a hard-coded 1, so the second-pass
+    // skip is a genuine version match rather than a coincidence.
+    val downloaded  = results.collect { case (s, Right(_)) =>
+      s.name -> registryClient.getLatestSchemaMetadata(s.name).getVersion.intValue
+    }
     val newManifest = IncrementalResolver.updatedManifest(manifest, downloaded)
+    newManifest.versionOf("test-subject-1") shouldBe Some(1)
 
     val decisions2  = IncrementalResolver.plan(
       newManifest,

--- a/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
@@ -1,61 +1,23 @@
 package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import org.apache.avro.Schema
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import scala.util.Try
 
-class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
-
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-
+  override protected def registerSubjects(): Unit =
     (1 to 5).foreach { i =>
       val schema = new AvroSchema(new Schema.Parser().parse(
         s"""{"type":"record","name":"Test$i","fields":[{"name":"id","type":"int"}]}""",
       ))
       registryClient.register(s"test-subject-$i", schema)
     }
-  }
-
-  override def afterAll(): Unit = {
-    Option(registryClient).foreach(c => Try(c.close()))
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
 
   private val silentLogger: Logger = Logger.Null
 

--- a/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
@@ -51,6 +51,7 @@ class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with B
   }
 
   override def afterAll(): Unit = {
+    Option(registryClient).foreach(c => Try(c.close()))
     Option(sr).foreach(c => Try(c.stop()))
     Option(kafka).foreach(c => Try(c.stop()))
     Option(network).foreach(c => Try(c.close()))
@@ -62,19 +63,25 @@ class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with B
 
   private val noRetry = RetryPolicy(maxRetries = 0, initialDelayMs = 1, backoffMultiplier = 1.0)
 
-  "ParallelDownloader integration" should "download 5 subjects concurrently" in {
-    val outDir     = tmpDir
-    val downloader = Downloader.withExternalClient(registryClient, outDir, silentLogger)
-    val subjects   = (1 to 5).map(i => RegistrySubject.Latest(s"test-subject-$i")).toList
+  "ParallelDownloader integration" should "download subjects concurrently (proven, not just counted)" in {
+    val outDir      = tmpDir
+    val parallelism = 4
+    // Gate getLatestSchemaMetadata on a barrier sized to parallelism: a sequential run can never
+    // get all `parallelism` calls in flight at once, so maxConcurrent would stay below it.
+    val probe       = ConcurrencyProbe.gating(registryClient, parallelism, Set("getLatestSchemaMetadata"))
+    val downloader  = Downloader.withExternalClient(probe.client, outDir, silentLogger)
+    val subjects    = (1 to parallelism).map(i => RegistrySubject.Latest(s"test-subject-$i")).toList
 
-    val pd      = ParallelDownloader(downloader, parallelism = 4, noRetry, silentLogger)
+    val pd      = ParallelDownloader(downloader, parallelism = parallelism, noRetry, silentLogger)
     val results = pd.downloadAll(subjects)
 
-    results should have size 5
-    results.count(_._2.isRight) shouldBe 5
+    results should have size parallelism.toLong
+    results.count(_._2.isRight) shouldBe parallelism
+    probe.maxConcurrent.get shouldBe parallelism // all tasks were in flight simultaneously
 
-    val files = outDir.toFile.listFiles()
-    files should have length 5
+    results.map(_._1.name).toSet shouldBe (1 to parallelism).map(i => s"test-subject-$i").toSet
+    outDir.toFile.listFiles().map(_.getName).toSet shouldBe
+      (1 to parallelism).map(i => s"test-subject-$i-1.avsc").toSet
   }
 
   it should "handle partial failure with mix of valid and invalid subjects" in {

--- a/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
@@ -107,17 +107,9 @@ class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with B
       Set("test-subject-1-1.avsc", "test-subject-3-1.avsc")
   }
 
-  it should "download sequentially with parallelism 1" in {
-    val outDir     = tmpDir
-    val downloader = Downloader.withExternalClient(registryClient, outDir, silentLogger)
-    val subjects   = (1 to 3).map(i => RegistrySubject.Latest(s"test-subject-$i")).toList
-
-    val pd      = ParallelDownloader(downloader, parallelism = 1, noRetry, silentLogger)
-    val results = pd.downloadAll(subjects)
-
-    results should have size 3
-    results.count(_._2.isRight) shouldBe 3
-  }
+  // Sequential (parallelism = 1) execution + order preservation is owned by ParallelDownloaderSpec
+  // ("execute sequentially when parallelism is 1 preserving order"), which asserts the actual order
+  // this IT never checked. Removed here as a registry-free duplicate.
 
   it should "compose correctly with incremental resolver" in {
     val outDir     = tmpDir

--- a/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
@@ -1,22 +1,15 @@
 package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.entities.{SchemaReference => ConfluentSchemaReference}
 import org.apache.avro.Schema
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import java.util.Collections
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 /** End-to-end reference resolution against a real Confluent Schema Registry.
   *
@@ -24,41 +17,9 @@ import scala.util.Try
   * `Integer`, nullable list) and composition of the resolver output with the existing
   * incremental and parallel download stages (FR-009).
   */
-class ReferenceResolutionIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
-
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
+class ReferenceResolutionIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
   private val silentLogger: Logger = Logger.Null
-
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-  }
-
-  override def afterAll(): Unit = {
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
 
   private def avroSchema(json: String): AvroSchema =
     new AvroSchema(new Schema.Parser().parse(json))

--- a/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
@@ -136,13 +136,22 @@ class ReferenceResolutionIntegrationSpec extends AnyFlatSpec with Matchers with 
     registerWithRefs(dep, depJson, List(new ConfluentSchemaReference("Base", base, 1)))
 
     val expanded = ReferenceResolver.resolve(List(RegistrySubject.latest(dep)), fetch).getOrElse(fail())
+    expanded should have size 2
 
-    val downloader = Downloader(registryUrl, dir, silentLogger)
-    try {
-      val parallel = ParallelDownloader(downloader, 2, RetryPolicy(maxRetries = 0), silentLogger)
-      val results  = parallel.downloadAll(expanded)
-      results.foreach { case (_, r) => r shouldBe a[Right[_, _]] }
-    } finally downloader.close()
+    // Resolved references are Pinned, so the parallel download fetches each via getByVersion; gate
+    // that on a 2-wide barrier to prove the two downloads actually overlap (not just both succeed).
+    val probe      = ConcurrencyProbe.gating(registryClient, 2, Set("getByVersion"))
+    val downloader = Downloader.withExternalClient(probe.client, dir, silentLogger)
+    val results =
+      try {
+        val parallel = ParallelDownloader(downloader, 2, RetryPolicy(maxRetries = 0), silentLogger)
+        parallel.downloadAll(expanded)
+      } finally downloader.close()
+
+    val bySubject = results.map { case (s, r) => s.name -> r }.toMap
+    bySubject(dep)  shouldBe a[Right[_, _]]
+    bySubject(base) shouldBe a[Right[_, _]]
+    probe.maxConcurrent.get shouldBe 2
 
     Files.exists(dir.resolve(s"$dep-1.avsc"))  shouldBe true
     Files.exists(dir.resolve(s"$base-1.avsc")) shouldBe true

--- a/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
@@ -81,6 +81,8 @@ class ReferenceResolutionIntegrationSpec extends AnyFlatSpec with Matchers with 
     finally Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
   }
 
+  private def readString(p: Path): String = new String(Files.readAllBytes(p))
+
   private val baseJson =
     """{"type":"record","name":"Base","namespace":"org.galaxio","fields":[{"name":"id","type":"long"}]}"""
   private val depJson  =
@@ -93,15 +95,20 @@ class ReferenceResolutionIntegrationSpec extends AnyFlatSpec with Matchers with 
       registryClient.register(base, avroSchema(baseJson))
       registerWithRefs(dep, depJson, List(new ConfluentSchemaReference("Base", base, 1)))
 
-      val expanded = ReferenceResolver.resolve(List(RegistrySubject.latest(dep)), fetch).getOrElse(fail())
-      expanded.map(_.name) should contain allOf (dep, base)
+      val expanded      = ReferenceResolver.resolve(List(RegistrySubject.latest(dep)), fetch).getOrElse(fail())
+      val expandedNamed = expanded.map(s => s.name -> s).toMap
+      // Exact expansion (not a subset), each resolved to pinned v1 (root first, then its reference).
+      expanded.map(_.name) should contain theSameElementsAs List(dep, base)
+      expandedNamed(dep)  shouldBe RegistrySubject.Pinned(dep, 1)
+      expandedNamed(base) shouldBe RegistrySubject.Pinned(base, 1)
 
       val downloader = Downloader(registryUrl, dir, silentLogger)
       try expanded.foreach(s => downloader.schemaSubjectToFile(s) shouldBe a[Right[_, _]])
       finally downloader.close()
 
-      Files.exists(dir.resolve(s"$dep-1.avsc"))  shouldBe true
-      Files.exists(dir.resolve(s"$base-1.avsc")) shouldBe true
+      // Both bodies are actually written and parseable — proves the refs were resolvable, not just that files exist.
+      new Schema.Parser().parse(readString(dir.resolve(s"$dep-1.avsc"))).getName  shouldBe "Dependent"
+      new Schema.Parser().parse(readString(dir.resolve(s"$base-1.avsc"))).getName shouldBe "Base"
     }
 
   it should "fail fast with the failing subject when a fetch fails (PS-4)" in {

--- a/it/src/test/scala/org/galaxio/avro/RegistrarIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/RegistrarIntegrationSpec.scala
@@ -1,53 +1,13 @@
 package org.galaxio.avro
 
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 import sbt.util.Logger
 
 import java.io.File
 import java.nio.file.{Files, Path}
-import scala.util.Try
 
-class RegistrarIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
-
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
-
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-  }
-
-  override def afterAll(): Unit = {
-    Option(registryClient).foreach(c => Try(c.close()))
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
+class RegistrarIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
   private def tempSchemaFile(content: String, suffix: String = ".avsc"): File = {
     val f = File.createTempFile("schema-it-", suffix)

--- a/it/src/test/scala/org/galaxio/avro/RegistrarIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/RegistrarIntegrationSpec.scala
@@ -96,29 +96,9 @@ class RegistrarIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndA
     first.head.toOption.get.schemaId shouldBe second.head.toOption.get.schemaId
   }
 
-  it should "return FileNotFound for missing schema file" in {
-    val results = Registrar.registerAll(
-      registryClient,
-      List(RegistryRegistration("it-missing-file", new File("/nonexistent/schema.avsc"))),
-    )
-
-    results should have size 1
-    results.head shouldBe a[Left[_, _]]
-    results.head.left.get shouldBe a[RegistryError.FileNotFound]
-  }
-
-  it should "return RegistrationFailed for invalid schema content" in {
-    val file = tempSchemaFile("not valid avro json {{{")
-
-    val results = Registrar.registerAll(
-      registryClient,
-      List(RegistryRegistration("it-invalid-schema", file)),
-    )
-
-    results should have size 1
-    results.head shouldBe a[Left[_, _]]
-    results.head.left.get shouldBe a[RegistryError.RegistrationFailed]
-  }
+  // FileNotFound (missing file) and RegistrationFailed (invalid Avro content) fail in readSchemaFile
+  // / buildParsedSchema before client.register — pure logic owned by RegistrarSpec. Removed here to
+  // avoid duplicating registry-free paths.
 
   it should "register a Protobuf schema with correct type" in {
     val protoContent =

--- a/it/src/test/scala/org/galaxio/avro/RegistrarIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/RegistrarIntegrationSpec.scala
@@ -77,6 +77,11 @@ class RegistrarIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndA
     val registered = results.head.toOption.get
     registered.subject shouldBe "it-register-test"
     registered.schemaId should be > 0
+
+    // The live registry must actually have stored it: read the schema back and parse it.
+    val meta = registryClient.getLatestSchemaMetadata("it-register-test")
+    meta.getSchemaType shouldBe "AVRO"
+    new org.apache.avro.Schema.Parser().parse(meta.getSchema).getFullName shouldBe "org.galaxio.RegTest"
   }
 
   it should "return same schema ID for idempotent registration" in {
@@ -190,6 +195,14 @@ class RegistrarIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndA
       List(RegistryRegistration("it-proto-ref-dep", depFile, SchemaType.Protobuf, depRefs)),
     )
     depRegs.head shouldBe a[Right[_, _]]
+
+    // Prove the reference was actually stored on the dependent subject (not silently dropped).
+    val refs = registryClient.getLatestSchemaMetadata("it-proto-ref-dep").getReferences
+    refs.size shouldBe 1
+    val ref = refs.get(0)
+    ref.getName shouldBe "BaseMsg.proto"
+    ref.getSubject shouldBe "it-proto-ref-base"
+    ref.getVersion.intValue shouldBe 1
   }
 
   it should "register JSON Schema with references" in {
@@ -216,6 +229,14 @@ class RegistrarIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndA
       List(RegistryRegistration("it-json-ref-dep", depFile, SchemaType.Json, depRefs)),
     )
     depRegs.head shouldBe a[Right[_, _]]
+
+    // Prove the reference was actually stored on the dependent subject (not silently dropped).
+    val refs = registryClient.getLatestSchemaMetadata("it-json-ref-dep").getReferences
+    refs.size shouldBe 1
+    val ref = refs.get(0)
+    ref.getName shouldBe "base.json"
+    ref.getSubject shouldBe "it-json-ref-base"
+    ref.getVersion.intValue shouldBe 1
   }
 
   it should "support round-trip: register then download matches" in withTempDir { dir =>

--- a/it/src/test/scala/org/galaxio/avro/SchemaRegistryContainerSuite.scala
+++ b/it/src/test/scala/org/galaxio/avro/SchemaRegistryContainerSuite.scala
@@ -1,0 +1,80 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+import scala.util.Try
+
+/** Boots one Kafka + Confluent Schema Registry (and a `CachedSchemaRegistryClient`) per spec that
+  * mixes this in — the boot/teardown block previously duplicated verbatim in every IT spec.
+  *
+  * DECISION: one registry PER spec, not a module-wide singleton. Specs such as
+  * `SubjectExplorerIntegrationSpec` assert the EXACT global subject list via `getAllSubjects`, and
+  * `SubjectResolverIntegrationSpec` registers `*User*`/`*-value` subjects that would leak across a
+  * shared registry and break those assertions; a singleton would also force
+  * `Test / parallelExecution := false` plus per-spec namespace isolation. Per-spec boot keeps every
+  * existing assertion valid at the cost of an unchanged boot count.
+  *
+  * Mix in, then use `registryUrl` / `registryClient`. Override `registerSubjects()` to seed fixtures
+  * after the client is ready. The client and containers are torn down in `afterAll`.
+  */
+trait SchemaRegistryContainerSuite extends BeforeAndAfterAll { self: Suite =>
+
+  /** Image tags, identical to the original inline boot blocks. */
+  protected def kafkaImage: String          = "confluentinc/cp-kafka:7.5.0"
+  protected def schemaRegistryImage: String = "confluentinc/cp-schema-registry:7.5.0"
+
+  /** Identity-cache capacity for the spec-facing client (was hard-coded to 100 in every spec). */
+  protected def clientCacheSize: Int = 100
+
+  @volatile private var network: Network               = _
+  @volatile private var kafka: ConfluentKafkaContainer = _
+  @volatile private var sr: JGenericContainer[_]       = _
+
+  /** Base URL of the booted Schema Registry, e.g. `http://localhost:32785`. */
+  protected var registryUrl: String = _
+
+  /** A client connected to [[registryUrl]]; usable from `registerSubjects()` and the tests. */
+  protected var registryClient: CachedSchemaRegistryClient = _
+
+  /** Override to seed subjects/fixtures once the registry and client are up. No-op by default. */
+  protected def registerSubjects(): Unit = ()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    network = Network.newNetwork()
+
+    kafka = new ConfluentKafkaContainer(DockerImageName.parse(kafkaImage))
+    kafka.withListener("kafka:19092")
+    kafka.withNetwork(network)
+    kafka.start()
+
+    sr = new JGenericContainer(DockerImageName.parse(schemaRegistryImage))
+    sr.withNetwork(network)
+    sr.withExposedPorts(8081)
+    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+    sr.start()
+
+    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
+    registryClient = new CachedSchemaRegistryClient(registryUrl, clientCacheSize)
+
+    registerSubjects()
+  }
+
+  override def afterAll(): Unit =
+    try {
+      // Close the client first (was inconsistently closed across specs), then the containers and
+      // network — each guarded so one failure never masks the rest.
+      Option(registryClient).foreach(c => Try(c.close()))
+      Option(sr).foreach(c => Try(c.stop()))
+      Option(kafka).foreach(c => Try(c.stop()))
+      Option(network).foreach(c => Try(c.close()))
+    } finally super.afterAll()
+}

--- a/it/src/test/scala/org/galaxio/avro/SchemaRegistryContainerSuite.scala
+++ b/it/src/test/scala/org/galaxio/avro/SchemaRegistryContainerSuite.scala
@@ -46,35 +46,46 @@ trait SchemaRegistryContainerSuite extends BeforeAndAfterAll { self: Suite =>
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    try {
+      network = Network.newNetwork()
 
-    network = Network.newNetwork()
+      kafka = new ConfluentKafkaContainer(DockerImageName.parse(kafkaImage))
+      kafka.withListener("kafka:19092")
+      kafka.withNetwork(network)
+      kafka.start()
 
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse(kafkaImage))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
+      sr = new JGenericContainer(DockerImageName.parse(schemaRegistryImage))
+      sr.withNetwork(network)
+      sr.withExposedPorts(8081)
+      sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+      sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+      sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+      sr.start()
 
-    sr = new JGenericContainer(DockerImageName.parse(schemaRegistryImage))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
+      registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
+      registryClient = new CachedSchemaRegistryClient(registryUrl, clientCacheSize)
 
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, clientCacheSize)
-
-    registerSubjects()
+      registerSubjects()
+    } catch {
+      case e: Throwable =>
+        // ScalaTest does NOT call afterAll when beforeAll throws — tear down here so a failed
+        // container start or registerSubjects() never leaks the partially-started containers.
+        stopQuietly()
+        throw e
+    }
   }
 
   override def afterAll(): Unit =
-    try {
-      // Close the client first (was inconsistently closed across specs), then the containers and
-      // network — each guarded so one failure never masks the rest.
-      Option(registryClient).foreach(c => Try(c.close()))
-      Option(sr).foreach(c => Try(c.stop()))
-      Option(kafka).foreach(c => Try(c.stop()))
-      Option(network).foreach(c => Try(c.close()))
-    } finally super.afterAll()
+    try stopQuietly()
+    finally super.afterAll()
+
+  /** Idempotent teardown: close the client first (was inconsistently closed across specs), then the
+    * containers and network — each guarded so one failure never masks the rest.
+    */
+  private def stopQuietly(): Unit = {
+    Option(registryClient).foreach(c => Try(c.close()))
+    Option(sr).foreach(c => Try(c.stop()))
+    Option(kafka).foreach(c => Try(c.stop()))
+    Option(network).foreach(c => Try(c.close()))
+  }
 }

--- a/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
@@ -76,19 +76,17 @@ class SubjectExplorerIntegrationSpec extends AnyFlatSpec with Matchers with Befo
     registryClient.updateCompatibility(orderSubject, "BACKWARD")
   }
 
-  "SubjectExplorer.listAll (integration)" should "list all subjects sorted with correct version ranges" in {
+  "SubjectExplorer.listAll (integration)" should "list all subjects sorted with their real versions" in {
     val result = SubjectExplorer.listAll(registryClient, None)
 
     result shouldBe a[Right[_, _]]
     val listing = result.right.get
     listing.subjects.map(_.name) shouldBe List(orderSubject, userSubject)
 
-    val order = listing.subjects.find(_.name == orderSubject).get
-    order.versions shouldBe List(1, 2)
-    order.versionRange shouldBe "1..2"
-
-    val user = listing.subjects.find(_.name == userSubject).get
-    user.versionRange shouldBe "1"
+    // Real getAllVersions over the two registered Order versions and the single User version.
+    // versionRange string formatting is pure and owned by SubjectInfoSpec.
+    listing.subjects.find(_.name == orderSubject).get.versions shouldBe List(1, 2)
+    listing.subjects.find(_.name == userSubject).get.versions  shouldBe List(1)
   }
 
   it should "surface a subject-level compatibility override and report None for subjects without one" in {
@@ -97,15 +95,7 @@ class SubjectExplorerIntegrationSpec extends AnyFlatSpec with Matchers with Befo
     listing.subjects.find(_.name == userSubject).get.compatibility shouldBe None
   }
 
-  it should "produce the same result with parallelism > 1 as sequential" in {
-    val seq = SubjectExplorer.listAll(registryClient, None).right.get
-    val par = SubjectExplorer.listAll(registryClient, None, parallelism = 4).right.get
-    par.subjects shouldBe seq.subjects
-  }
-
-  it should "narrow the listing with a case-insensitive filter" in {
-    val listing = SubjectExplorer.listAll(registryClient, Some("order")).right.get
-    listing.subjects.map(_.name) shouldBe List(orderSubject)
-    listing.size shouldBe 1
-  }
+  // Parallel-equals-sequential and case-insensitive filtering are pure (BoundedParallel preserves
+  // order; SubjectListing.nameMatches owns the predicate) and are covered by SubjectExplorerSpec.
+  // Removed here as registry-free duplicates.
 }

--- a/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
@@ -1,56 +1,16 @@
 package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import org.apache.avro.Schema
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 
-import scala.util.Try
-
-class SubjectExplorerIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
-
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
+class SubjectExplorerIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
   private val orderSubject = "it.e2e.Order-value"
   private val userSubject  = "it.e2e.User-value"
 
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-
-    registerTestSubjects()
-  }
-
-  override def afterAll(): Unit = {
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
+  override protected def registerSubjects(): Unit = registerTestSubjects()
 
   private def avro(json: String): AvroSchema =
     new AvroSchema(new Schema.Parser().parse(json))

--- a/it/src/test/scala/org/galaxio/avro/SubjectResolverIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/SubjectResolverIntegrationSpec.scala
@@ -1,53 +1,13 @@
 package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import org.apache.avro.Schema
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.kafka.ConfluentKafkaContainer
-import org.testcontainers.utility.DockerImageName
 
-import scala.util.Try
+class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with SchemaRegistryContainerSuite {
 
-class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
-
-  private var network: Network                           = _
-  private var kafka: ConfluentKafkaContainer             = _
-  private var sr: JGenericContainer[_]                   = _
-  private var registryUrl: String                        = _
-  private var registryClient: CachedSchemaRegistryClient = _
-
-  override def beforeAll(): Unit = {
-    network = Network.newNetwork()
-
-    kafka = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
-    kafka.withListener("kafka:19092")
-    kafka.withNetwork(network)
-    kafka.start()
-
-    sr = new JGenericContainer(DockerImageName.parse("confluentinc/cp-schema-registry:7.5.0"))
-    sr.withNetwork(network)
-    sr.withExposedPorts(8081)
-    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
-    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
-    sr.start()
-
-    registryUrl = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
-    registryClient = new CachedSchemaRegistryClient(registryUrl, 100)
-
-    registerTestSubjects()
-  }
-
-  override def afterAll(): Unit = {
-    Option(sr).foreach(c => Try(c.stop()))
-    Option(kafka).foreach(c => Try(c.stop()))
-    Option(network).foreach(c => Try(c.close()))
-  }
+  override protected def registerSubjects(): Unit = registerTestSubjects()
 
   private def avroSchema(name: String): AvroSchema =
     new AvroSchema(

--- a/it/src/test/scala/org/galaxio/avro/SubjectResolverIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/SubjectResolverIntegrationSpec.scala
@@ -59,8 +59,6 @@ class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with Befo
   private def registerTestSubjects(): Unit = {
     registryClient.register("com.myorg.User-value", avroSchema("User"))
     registryClient.register("com.myorg.Order-value", avroSchema("Order"))
-    // Second registration creates version 2 so pinned-version test can assert version 1 vs latest
-    registryClient.register("com.myorg.User-value", avroSchema("User"))
     registryClient.register("internal.Audit-value", avroSchema("Audit"))
   }
 
@@ -75,23 +73,8 @@ class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with Befo
     names should contain theSameElementsAs List("com.myorg.User-value", "com.myorg.Order-value")
   }
 
-  it should "return empty plan when pattern matches zero subjects" in {
-    val specs  = List(SubjectSpec.Pattern("nonexistent\\..*"))
-    val result = SubjectResolver.resolve(registryClient, specs)
-
-    result shouldBe Right(DownloadPlan(Nil))
-  }
-
-  it should "resolve pattern-matched subjects as Latest" in {
-    val specs  = List(SubjectSpec.Pattern("com\\.myorg\\.User-value"))
-    val result = SubjectResolver.resolve(registryClient, specs)
-
-    result shouldBe a[Right[_, _]]
-    result.right.get.subjects.foreach {
-      case _: RegistrySubject.Latest => succeed
-      case other                     => fail(s"Expected Latest, got $other")
-    }
-  }
+  // Empty-plan and pattern-resolves-to-Latest are pure regex/mapping logic owned by
+  // SubjectResolverSpec; removed here as registry-free duplicates.
 
   // --- US2: Exact + pattern composition ---
 
@@ -110,12 +93,8 @@ class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with Befo
     plan.subjects.map(_.name) should contain("com.myorg.Order-value")
   }
 
-  it should "work with only exact specs (no pattern resolution)" in {
-    val specs  = List(SubjectSpec.Exact(RegistrySubject.Latest("com.myorg.User-value")))
-    val result = SubjectResolver.resolve(registryClient, specs)
-
-    result shouldBe Right(DownloadPlan(List(RegistrySubject.Latest("com.myorg.User-value"))))
-  }
+  // Exact-only resolution touches the registry zero times — owned by SubjectResolverSpec
+  // ("return exact subjects as-is" / "not call getAllSubjects when only exact specs provided").
 
   // --- US3: Multiple patterns ---
 
@@ -133,15 +112,6 @@ class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with Befo
     )
   }
 
-  it should "deduplicate across overlapping patterns" in {
-    val specs = List(
-      SubjectSpec.Pattern("com\\.myorg\\..*"),
-      SubjectSpec.Pattern(".*User.*"),
-    )
-    val result = SubjectResolver.resolve(registryClient, specs)
-
-    result shouldBe a[Right[_, _]]
-    val names = result.right.get.subjects.map(_.name)
-    names.count(_ == "com.myorg.User-value") shouldBe 1
-  }
+  // Overlapping-pattern deduplication is pure set logic owned by SubjectResolverSpec
+  // ("deduplicate across multiple patterns matching the same subject").
 }

--- a/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
+++ b/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
@@ -1,0 +1,147 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import sbt.util.Logger
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.util.Try
+
+/** Resolved inputs for one `schemaRegistryDownload` run, decoupled from sbt settings so the orchestration can be unit-tested.
+  */
+final case class DownloadConfig(
+    subjects: Seq[RegistrySubject],
+    patterns: Seq[String],
+    incremental: Boolean,
+    parallelism: Int,
+    retries: Int,
+    resolveReferences: Boolean,
+    targetFolder: Path,
+    manifestFile: Path,
+)
+
+/** Outcome of a download run. `failed` is per-subject and non-fatal here — the caller decides whether to fail the build. */
+final case class DownloadSummary(
+    succeeded: Int,
+    skipped: Int,
+    failed: List[(RegistrySubject, DownloadError)],
+)
+
+/** Pure-ish core of the download task: pattern resolution → reference expansion → incremental planning → bounded-parallel
+  * download → manifest update. The only effects are the injected `client`, manifest file IO and logging, so it is exercisable
+  * with a mocked `SchemaRegistryClient` and a temp directory. `Left` is a fatal resolve/expand failure; per-subject download
+  * failures are reported in [[DownloadSummary.failed]].
+  */
+object DownloadOrchestrator {
+
+  def run(
+      client: SchemaRegistryClient,
+      cfg: DownloadConfig,
+      logger: Logger,
+  ): Either[DownloadError, DownloadSummary] =
+    for {
+      resolvedSubjects <- resolveSubjects(client, cfg, logger)
+      expandedSubjects <- expandReferences(client, cfg, resolvedSubjects, logger)
+    } yield download(client, cfg, expandedSubjects, logger)
+
+  private def resolveSubjects(
+      client: SchemaRegistryClient,
+      cfg: DownloadConfig,
+      logger: Logger,
+  ): Either[DownloadError, List[RegistrySubject]] =
+    if (cfg.patterns.isEmpty) Right(cfg.subjects.toList)
+    else {
+      val specs =
+        cfg.subjects.map(s => SubjectSpec.Exact(s)).toList ++ cfg.patterns.map(SubjectSpec.Pattern).toList
+      SubjectResolver.resolve(client, specs).map { plan =>
+        logger.info(s"Resolved ${plan.subjects.size} subject(s) from patterns")
+        plan.subjects.toList
+      }
+    }
+
+  private def expandReferences(
+      client: SchemaRegistryClient,
+      cfg: DownloadConfig,
+      resolved: List[RegistrySubject],
+      logger: Logger,
+  ): Either[DownloadError, List[RegistrySubject]] =
+    if (!cfg.resolveReferences) Right(resolved)
+    else
+      ReferenceResolver.resolve(resolved, Downloader.referenceFetch(client)).map { expanded =>
+        val extra = expanded.size - resolved.size
+        if (extra > 0) logger.info(s"Resolved $extra referenced schema(s)")
+        expanded
+      }
+
+  private def download(
+      client: SchemaRegistryClient,
+      cfg: DownloadConfig,
+      expandedSubjects: List[RegistrySubject],
+      logger: Logger,
+  ): DownloadSummary = {
+    val manifest = loadManifest(cfg.manifestFile, cfg.incremental, logger)
+
+    val decisions =
+      if (cfg.incremental)
+        IncrementalResolver.plan(
+          manifest,
+          expandedSubjects,
+          s =>
+            Try(client.getLatestSchemaMetadata(s).getVersion: Int).toEither.left
+              .map(DownloadError.SchemaFetchFailed(s, _)),
+        )
+      else
+        expandedSubjects.map(s => DownloadDecision.Download(s, "incremental disabled"))
+
+    val (skips, downloads) = decisions.partition {
+      case _: DownloadDecision.Skip => true
+      case _                        => false
+    }
+
+    skips.foreach {
+      case DownloadDecision.Skip(name, v) => logger.info(s"$name v$v → up to date")
+      case _                              => ()
+    }
+
+    val downloader         =
+      Downloader.withExternalClient(client, cfg.targetFolder, logger)
+    val retryPolicy        = RetryPolicy(maxRetries = cfg.retries)
+    val parallelDownloader = ParallelDownloader(downloader, cfg.parallelism, retryPolicy, logger)
+
+    val toDownload = downloads.collect { case d: DownloadDecision.Download => d }
+    toDownload.foreach(d => logger.info(s"${d.subject.name}: ${d.reason}"))
+
+    val downloadResults = parallelDownloader.downloadAll(toDownload.map(_.subject))
+
+    val decisionsMap = toDownload.map(d => d.subject.name -> d).toMap
+    val failures     = downloadResults.collect { case (s, Left(e)) => s -> e }
+
+    val downloaded = downloadResults.collect { case (s, Right(_)) =>
+      decisionsMap.get(s.name).flatMap(_.resolvedVersion).map(s.name -> _)
+    }.flatten
+
+    if (cfg.incremental && downloaded.nonEmpty) {
+      val newManifest = IncrementalResolver.updatedManifest(manifest, downloaded)
+      writeManifest(cfg.manifestFile, newManifest, logger)
+    }
+
+    DownloadSummary(downloadResults.count(_._2.isRight), skips.size, failures)
+  }
+
+  private[avro] def loadManifest(path: Path, incremental: Boolean, logger: Logger): VersionManifest =
+    if (!incremental || !Files.exists(path)) VersionManifest.empty
+    else
+      Try(new String(Files.readAllBytes(path), StandardCharsets.UTF_8)).toEither
+        .flatMap(VersionManifest.fromJson) match {
+        case Right(m) => m
+        case Left(_)  =>
+          logger.warn("Version manifest corrupted, re-downloading all schemas")
+          VersionManifest.empty
+      }
+
+  private[avro] def writeManifest(path: Path, manifest: VersionManifest, logger: Logger): Unit =
+    Try {
+      Files.createDirectories(path.getParent)
+      Files.write(path, manifest.toJson.getBytes(StandardCharsets.UTF_8))
+    }.failed.foreach(e => logger.warn(s"Failed to write version manifest: ${e.getMessage}"))
+}

--- a/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
+++ b/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
@@ -113,11 +113,14 @@ object DownloadOrchestrator {
 
     val downloadResults = parallelDownloader.downloadAll(toDownload.map(_.subject))
 
-    val decisionsMap = toDownload.map(d => d.subject.name -> d).toMap
-    val failures     = downloadResults.collect { case (s, Left(e)) => s -> e }
+    // Key by the full subject (name + version), not just name: reference resolution can yield
+    // divergent pinned versions of the same subject, and a name-only map collapses them — wiring a
+    // succeeded download to the wrong decision's resolved version in the manifest.
+    val decisionsBySubject = toDownload.map(d => d.subject -> d).toMap
+    val failures           = downloadResults.collect { case (s, Left(e)) => s -> e }
 
     val downloaded = downloadResults.collect { case (s, Right(_)) =>
-      decisionsMap.get(s.name).flatMap(_.resolvedVersion).map(s.name -> _)
+      decisionsBySubject.get(s).flatMap(_.resolvedVersion).map(s.name -> _)
     }.flatten
 
     if (cfg.incremental && downloaded.nonEmpty) {

--- a/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
+++ b/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
@@ -39,10 +39,24 @@ object DownloadOrchestrator {
       cfg: DownloadConfig,
       logger: Logger,
   ): Either[DownloadError, DownloadSummary] =
-    for {
-      resolvedSubjects <- resolveSubjects(client, cfg, logger)
-      expandedSubjects <- expandReferences(client, cfg, resolvedSubjects, logger)
-    } yield download(client, cfg, expandedSubjects, logger)
+    validate(cfg) match {
+      case Some(err) => Left(err)
+      case None      =>
+        for {
+          resolvedSubjects <- resolveSubjects(client, cfg, logger)
+          expandedSubjects <- expandReferences(client, cfg, resolvedSubjects, logger)
+        } yield download(client, cfg, expandedSubjects, logger)
+    }
+
+  /** First range violation in the config, if any — shared with the plugin so it can fail fast before opening a registry client.
+    * Keeps the orchestrator self-contained for direct callers.
+    */
+  def validate(cfg: DownloadConfig): Option[DownloadError] =
+    if (cfg.parallelism < 1 || cfg.parallelism > ParallelDownloader.MaxParallelism)
+      Some(DownloadError.InvalidParallelism(cfg.parallelism))
+    else if (cfg.retries < 0 || cfg.retries > ParallelDownloader.MaxRetries)
+      Some(DownloadError.InvalidRetryConfig(cfg.retries))
+    else None
 
   private def resolveSubjects(
       client: SchemaRegistryClient,

--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -3,6 +3,7 @@ package org.galaxio.avro
 import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaRegistryClient}
 import sbt.util.Logger
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.{Collections, HashMap => JHashMap}
 import scala.collection.JavaConverters._
@@ -59,7 +60,7 @@ final class Downloader private[avro] (
     Try {
       if (Files.notExists(schemaOutputDir)) Files.createDirectories(schemaOutputDir)
       val fileName = s"$subjectName-$version.${schemaType.extension}"
-      val path     = Files.write(schemaOutputDir.resolve(fileName), body.getBytes())
+      val path     = Files.write(schemaOutputDir.resolve(fileName), body.getBytes(StandardCharsets.UTF_8))
       logger.info(s"Saved schema $subjectName to $path")
       path
     }.toEither.left.map(DownloadError.WriteError(schemaOutputDir, _))

--- a/src/main/scala/org/galaxio/avro/EitherOps.scala
+++ b/src/main/scala/org/galaxio/avro/EitherOps.scala
@@ -1,0 +1,22 @@
+package org.galaxio.avro
+
+/** Either combinators shared by the resolver/explorer pipelines. */
+private[avro] object EitherOps {
+
+  /** Collapse a list of results into a result of a list, short-circuiting to the FIRST `Left` in input order. */
+  def sequence[E, A](results: List[Either[E, A]]): Either[E, List[A]] =
+    traverse(results)(identity)
+
+  /** Map each element to an `Either` and collect, short-circuiting to the FIRST `Left` in input order. Once a `Left` is hit,
+    * `f` is not evaluated for the remaining elements.
+    */
+  def traverse[A, E, B](items: List[A])(f: A => Either[E, B]): Either[E, List[B]] =
+    items
+      .foldLeft(Right(Nil): Either[E, List[B]]) { (acc, a) =>
+        for {
+          xs <- acc
+          x  <- f(a)
+        } yield x :: xs
+      }
+      .map(_.reverse)
+}

--- a/src/main/scala/org/galaxio/avro/RetryPolicy.scala
+++ b/src/main/scala/org/galaxio/avro/RetryPolicy.scala
@@ -17,15 +17,18 @@ final case class RetryPolicy(
     var attempt    = 0
     while (attempt < maxRetries && isRetryable(lastResult)) {
       attempt += 1
-      val delayMs = (initialDelayMs * math.pow(backoffMultiplier, attempt - 1)).toLong
       lastResult.left.foreach { err =>
         logger.warn(s"Retry $attempt/$maxRetries for $subjectName: ${err.message}")
       }
-      Thread.sleep(delayMs)
+      Thread.sleep(delayMs(attempt))
       lastResult = op
     }
     lastResult
   }
+
+  /** Exponential backoff delay before the n-th retry (1-based): `initialDelayMs * backoffMultiplier^(attempt-1)`. */
+  private[avro] def delayMs(attempt: Int): Long =
+    (initialDelayMs * math.pow(backoffMultiplier, attempt - 1)).toLong
 
   private def isRetryable[A](result: Either[DownloadError, A]): Boolean =
     result match {

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -90,10 +90,8 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       logger.debug(s"schemaRegistryRetries: $retries")
       logger.debug(s"schemaRegistryResolveReferences: ${cfg.resolveReferences}")
 
-      if (parallelism < 1 || parallelism > ParallelDownloader.MaxParallelism)
-        sys.error(DownloadError.InvalidParallelism(parallelism).message)
-      if (retries < 0 || retries > ParallelDownloader.MaxRetries)
-        sys.error(DownloadError.InvalidRetryConfig(retries).message)
+      // Fail fast on bad ranges before opening a registry client (shared with the orchestrator).
+      DownloadOrchestrator.validate(cfg).foreach(err => sys.error(err.message))
 
       if (subjects.isEmpty && patterns.isEmpty) {
         logger.warn(

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -4,9 +4,7 @@ import _root_.io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import sbt.*
 import Keys.*
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path => JPath}
-import scala.util.{Try, Using}
+import scala.util.Using
 
 object SchemaDownloaderPlugin extends AutoPlugin {
   override def trigger = allRequirements
@@ -63,44 +61,34 @@ object SchemaDownloaderPlugin extends AutoPlugin {
   )(f: SchemaRegistryClient => A): A =
     Using.resource(Downloader.buildClient(url, cacheSize, auth, properties))(f)
 
-  private def loadManifest(path: JPath, incremental: Boolean, logger: sbt.util.Logger): VersionManifest =
-    if (!incremental || !Files.exists(path)) VersionManifest.empty
-    else
-      Try(new String(Files.readAllBytes(path), StandardCharsets.UTF_8)).toEither
-        .flatMap(VersionManifest.fromJson) match {
-        case Right(m) => m
-        case Left(_)  =>
-          logger.warn("Version manifest corrupted, re-downloading all schemas")
-          VersionManifest.empty
-      }
-
-  private def writeManifest(path: JPath, manifest: VersionManifest, logger: sbt.util.Logger): Unit =
-    Try {
-      Files.createDirectories(path.getParent)
-      Files.write(path, manifest.toJson.getBytes(StandardCharsets.UTF_8))
-    }.failed.foreach(e => logger.warn(s"Failed to write version manifest: ${e.getMessage}"))
-
   override lazy val projectSettings: Seq[Setting[?]] = defaultSettings ++ Seq(
     schemaRegistryDownload                    := (Compile / schemaRegistryDownload).value,
     Compile / schemaRegistryDownload          := {
-      val logger       = streams.value.log
-      val subjects     = schemaRegistrySubjects.value
-      val patterns     = schemaRegistrySubjectPatterns.value
-      val incremental  = schemaRegistryIncremental.value
-      val parallelism  = schemaRegistryParallelism.value
-      val retries      = schemaRegistryRetries.value
-      val resolveRefs  = schemaRegistryResolveReferences.value
-      val manifestFile =
-        streams.value.cacheDirectory.toPath.resolve(".schema-versions.json")
+      val logger      = streams.value.log
+      val subjects    = schemaRegistrySubjects.value
+      val patterns    = schemaRegistrySubjectPatterns.value
+      val parallelism = schemaRegistryParallelism.value
+      val retries     = schemaRegistryRetries.value
+
+      val cfg = DownloadConfig(
+        subjects = subjects,
+        patterns = patterns,
+        incremental = schemaRegistryIncremental.value,
+        parallelism = parallelism,
+        retries = retries,
+        resolveReferences = schemaRegistryResolveReferences.value,
+        targetFolder = schemaRegistryTargetFolder.value.toPath,
+        manifestFile = streams.value.cacheDirectory.toPath.resolve(".schema-versions.json"),
+      )
 
       logger.debug(s"schemaRegistryUrl: ${schemaRegistryUrl.value}")
-      logger.debug(s"schemaRegistryTargetFolder: ${schemaRegistryTargetFolder.value}")
+      logger.debug(s"schemaRegistryTargetFolder: ${cfg.targetFolder}")
       logger.debug(s"schemaRegistrySubjects: ${subjects.mkString(", ")}")
       logger.debug(s"schemaRegistrySubjectPatterns: ${patterns.mkString(", ")}")
-      logger.debug(s"schemaRegistryIncremental: $incremental")
+      logger.debug(s"schemaRegistryIncremental: ${cfg.incremental}")
       logger.debug(s"schemaRegistryParallelism: $parallelism")
       logger.debug(s"schemaRegistryRetries: $retries")
-      logger.debug(s"schemaRegistryResolveReferences: $resolveRefs")
+      logger.debug(s"schemaRegistryResolveReferences: ${cfg.resolveReferences}")
 
       if (parallelism < 1 || parallelism > ParallelDownloader.MaxParallelism)
         sys.error(DownloadError.InvalidParallelism(parallelism).message)
@@ -118,95 +106,20 @@ object SchemaDownloaderPlugin extends AutoPlugin {
           schemaRegistryAuth.value,
           schemaRegistryProperties.value,
         ) { client =>
-          val resolvedSubjects = if (patterns.isEmpty) {
-            subjects
-          } else {
-            val specs =
-              subjects.map(s => SubjectSpec.Exact(s)).toList ++
-                patterns.map(SubjectSpec.Pattern).toList
-
-            SubjectResolver.resolve(client, specs) match {
-              case Left(err)   =>
-                err.cause.foreach(logger.trace(_))
-                sys.error(err.message)
-              case Right(plan) =>
-                logger.info(s"Resolved ${plan.subjects.size} subject(s) from patterns")
-                plan.subjects
-            }
-          }
-
-          val expandedSubjects: List[RegistrySubject] =
-            if (!resolveRefs) resolvedSubjects.toList
-            else {
-              val fetch = Downloader.referenceFetch(client)
-
-              ReferenceResolver.resolve(resolvedSubjects.toList, fetch) match {
-                case Left(err)       =>
-                  err.cause.foreach(logger.trace(_))
-                  sys.error(err.message)
-                case Right(expanded) =>
-                  val extra = expanded.size - resolvedSubjects.size
-                  if (extra > 0) logger.info(s"Resolved $extra referenced schema(s)")
-                  expanded
+          DownloadOrchestrator.run(client, cfg, logger) match {
+            case Left(err)      =>
+              err.cause.foreach(logger.trace(_))
+              sys.error(err.message)
+            case Right(summary) =>
+              if (summary.failed.nonEmpty) {
+                summary.failed.foreach { case (s, e) =>
+                  logger.error(s"Failed to download schema ${s.name}: ${e.message}")
+                  e.cause.foreach(logger.trace(_))
+                }
+                sys.error(s"Failed to download ${summary.failed.size} schema(s)")
               }
-            }
-
-          val manifest = loadManifest(manifestFile, incremental, logger)
-
-          val decisions =
-            if (incremental)
-              IncrementalResolver.plan(
-                manifest,
-                expandedSubjects,
-                s =>
-                  Try(client.getLatestSchemaMetadata(s).getVersion: Int).toEither.left
-                    .map(DownloadError.SchemaFetchFailed(s, _)),
-              )
-            else
-              expandedSubjects.map(s => DownloadDecision.Download(s, "incremental disabled"))
-
-          val (skips, downloads) = decisions.partition {
-            case _: DownloadDecision.Skip => true
-            case _                        => false
+              logger.info(s"${summary.succeeded} downloaded, ${summary.skipped} skipped, ${summary.failed.size} failed")
           }
-
-          skips.foreach {
-            case DownloadDecision.Skip(name, v) => logger.info(s"$name v$v → up to date")
-            case _                              => ()
-          }
-
-          val downloader         =
-            Downloader.withExternalClient(client, schemaRegistryTargetFolder.value.toPath, logger)
-          val retryPolicy        = RetryPolicy(maxRetries = retries)
-          val parallelDownloader = ParallelDownloader(downloader, parallelism, retryPolicy, logger)
-
-          val toDownload = downloads.collect { case d: DownloadDecision.Download => d }
-          toDownload.foreach(d => logger.info(s"${d.subject.name}: ${d.reason}"))
-
-          val downloadResults = parallelDownloader.downloadAll(toDownload.map(_.subject))
-
-          val decisionsMap = toDownload.map(d => d.subject.name -> d).toMap
-          val failures     = downloadResults.collect { case (s, Left(e)) => s -> e }
-
-          val downloaded = downloadResults.collect { case (s, Right(_)) =>
-            decisionsMap.get(s.name).flatMap(_.resolvedVersion).map(s.name -> _)
-          }.flatten
-
-          if (incremental && downloaded.nonEmpty) {
-            val newManifest = IncrementalResolver.updatedManifest(manifest, downloaded)
-            writeManifest(manifestFile, newManifest, logger)
-          }
-
-          if (failures.nonEmpty) {
-            failures.foreach { case (s, e) =>
-              logger.error(s"Failed to download schema ${s.name}: ${e.message}")
-              e.cause.foreach(logger.trace(_))
-            }
-            sys.error(s"Failed to download ${failures.size} schema(s)")
-          }
-
-          val succeeded = downloadResults.count(_._2.isRight)
-          logger.info(s"$succeeded downloaded, ${skips.size} skipped, ${failures.size} failed")
         }
       }
     },

--- a/src/main/scala/org/galaxio/avro/SubjectExplorer.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectExplorer.scala
@@ -39,20 +39,7 @@ object SubjectExplorer {
   ): Either[DownloadError, List[SubjectInfo]] =
     Try(BoundedParallel.traverse(names, parallelism)(fetchInfo(client, _))).toEither.left
       .map(DownloadError.SubjectListFailed)
-      .flatMap(firstError)
-
-  // Single pass: accumulate in order, short-circuit to the FIRST Left (subject order).
-  private def firstError(
-      results: List[Either[DownloadError, SubjectInfo]],
-  ): Either[DownloadError, List[SubjectInfo]] =
-    results
-      .foldLeft(Right(Nil): Either[DownloadError, List[SubjectInfo]]) { (acc, e) =>
-        for {
-          xs <- acc
-          x  <- e
-        } yield x :: xs
-      }
-      .map(_.reverse)
+      .flatMap(EitherOps.sequence)
 
   private def fetchInfo(
       client: SchemaRegistryClient,

--- a/src/main/scala/org/galaxio/avro/SubjectInfo.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectInfo.scala
@@ -5,8 +5,6 @@ final case class SubjectInfo(
     versions: List[Int],
     compatibility: Option[String],
 ) {
-  def latestVersion: Option[Int] = versions.lastOption
-
   def versionRange: String = versions match {
     case Nil      => "none"
     case v :: Nil => v.toString

--- a/src/main/scala/org/galaxio/avro/SubjectListing.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectListing.scala
@@ -2,16 +2,12 @@ package org.galaxio.avro
 
 final case class SubjectListing(subjects: List[SubjectInfo]) {
   def size: Int = subjects.size
-
-  /** Keep subjects whose name matches `filter` (case-insensitive substring). Empty filter matches all. */
-  def matching(filter: String): SubjectListing =
-    copy(subjects = subjects.filter(s => SubjectListing.nameMatches(s.name, filter)))
 }
 
 object SubjectListing {
 
-  /** The one definition of the list-subjects filter predicate: case-insensitive substring on the subject name. Used both for
-    * pre-fetch name filtering (`SubjectExplorer`) and post-fetch listing filtering (`matching`).
+  /** The one definition of the list-subjects filter predicate: case-insensitive substring on the subject name. Used for
+    * pre-fetch name filtering in `SubjectExplorer`.
     */
   def nameMatches(name: String, filter: String): Boolean =
     name.toLowerCase.contains(filter.toLowerCase)

--- a/src/main/scala/org/galaxio/avro/SubjectResolver.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectResolver.scala
@@ -35,15 +35,7 @@ object SubjectResolver {
   private def compilePatterns(
       regexes: List[String],
   ): Either[DownloadError, List[scala.util.matching.Regex]] =
-    regexes
-      .foldLeft(Right(Nil): Either[DownloadError, List[scala.util.matching.Regex]]) { (acc, r) =>
-        acc.flatMap { compiled =>
-          Try(r.r).toEither.left
-            .map(e => DownloadError.InvalidPattern(r, e))
-            .map(_ :: compiled)
-        }
-      }
-      .map(_.reverse)
+    EitherOps.traverse(regexes)(r => Try(r.r).toEither.left.map(e => DownloadError.InvalidPattern(r, e)))
 
   // Loads all subjects into memory; O(subjects × patterns) filtering
   private def matchSubjects(

--- a/src/test/scala/org/galaxio/avro/BoundedParallelSpec.scala
+++ b/src/test/scala/org/galaxio/avro/BoundedParallelSpec.scala
@@ -3,6 +3,9 @@ package org.galaxio.avro
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
 class BoundedParallelSpec extends AnyFlatSpec with Matchers {
 
   "BoundedParallel.traverse" should "return Nil for empty input" in {
@@ -29,11 +32,43 @@ class BoundedParallelSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "actually run elements concurrently when parallelism > 1" in {
-    // 4 tasks each sleeping 200ms on a pool of 4 finish well under the 800ms sequential sum.
-    val start   = System.nanoTime()
-    val results = BoundedParallel.traverse(List(1, 2, 3, 4), 4) { i => Thread.sleep(200); i }
-    val elapsed = (System.nanoTime() - start) / 1000000
-    results shouldBe List(1, 2, 3, 4)
-    elapsed should be < 700L
+    // Deterministic proof (no timing margins): every task blocks on a shared latch that only
+    // reaches zero once ALL `parallelism` tasks are running at once. If traverse ran sequentially
+    // the first task would wait forever and time out → await returns false and the test fails.
+    val parallelism = 4
+    val latch       = new CountDownLatch(parallelism)
+    val current     = new AtomicInteger(0)
+    val maxObserved = new AtomicInteger(0)
+
+    val results = BoundedParallel.traverse((1 to parallelism).toList, parallelism) { i =>
+      val running    = current.incrementAndGet()
+      maxObserved.getAndUpdate(prev => math.max(prev, running))
+      latch.countDown()
+      val allStarted = latch.await(10, TimeUnit.SECONDS)
+      current.decrementAndGet()
+      allStarted shouldBe true
+      i
+    }
+
+    results shouldBe (1 to parallelism).toList
+    maxObserved.get shouldBe parallelism // all `parallelism` tasks were in flight simultaneously
+  }
+
+  it should "never exceed the parallelism bound" in {
+    // 12 overlapping tasks (each briefly sleeping) on a pool of 3: a correct bound keeps the live
+    // count <= 3 at every instant. A pool that over-subscribes would record a violation.
+    val parallelism = 3
+    val current     = new AtomicInteger(0)
+    val violations  = new AtomicInteger(0)
+
+    val results = BoundedParallel.traverse((1 to 12).toList, parallelism) { i =>
+      if (current.incrementAndGet() > parallelism) violations.incrementAndGet()
+      Thread.sleep(20)
+      current.decrementAndGet()
+      i
+    }
+
+    results shouldBe (1 to 12).toList
+    violations.get shouldBe 0
   }
 }

--- a/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
@@ -90,6 +90,21 @@ class DownloadOrchestratorSpec extends AnyFlatSpec with Matchers with MockitoSug
     readManifest(cfg.manifestFile).versions shouldBe Map("svc" -> 1)
   }
 
+  it should "record the version actually downloaded for divergent pinned versions of one subject" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    // Same subject name, two pinned versions: v1 succeeds, v2 fails. The manifest must record v1
+    // (the one that landed), not v2 — a name-keyed join would mis-record the last decision's version.
+    when(client.getByVersion("dup", 1, false)).thenReturn(schemaEntity("dup", 1, """{"type":"string"}"""))
+    when(client.getByVersion("dup", 2, false)).thenThrow(new IOException("v2 gone"))
+
+    val cfg     = config(dir, Seq(RegistrySubject("dup", 1), RegistrySubject("dup", 2)))
+    val summary = DownloadOrchestrator.run(client, cfg, testLogger)
+
+    summary.map(_.succeeded) shouldBe Right(1)
+    summary.map(_.failed.map(_._1)) shouldBe Right(List(RegistrySubject.Pinned("dup", 2)))
+    readManifest(cfg.manifestFile).versions shouldBe Map("dup" -> 1)
+  }
+
   it should "fail fast with Left when a subject pattern is an invalid regex" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     val cfg    = config(dir, Seq.empty).copy(patterns = Seq("["))

--- a/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
@@ -1,0 +1,115 @@
+package org.galaxio.avro
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema
+import io.confluent.kafka.schemaregistry.client.{SchemaMetadata, SchemaRegistryClient}
+import org.mockito.ArgumentMatchers.{anyBoolean, anyInt, anyString}
+import org.mockito.Mockito.{verify, when}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sbt.util.Logger
+
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Collections
+
+class DownloadOrchestratorSpec extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  private def testLogger: Logger = mock[Logger]
+
+  private def withTempDir(test: Path => Any): Unit = {
+    val dir = Files.createTempDirectory("orchestrator-test")
+    try test(dir)
+    finally Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists)
+  }
+
+  private def schemaEntity(subject: String, version: Int, body: String): Schema =
+    new Schema(subject, version, 1, "AVRO", Collections.emptyList(), body)
+
+  private def config(dir: Path, subjects: Seq[RegistrySubject]): DownloadConfig =
+    DownloadConfig(
+      subjects = subjects,
+      patterns = Seq.empty,
+      incremental = true,
+      parallelism = 1,
+      retries = 0,
+      resolveReferences = false,
+      targetFolder = dir.resolve("avro"),
+      manifestFile = dir.resolve("cache").resolve(".schema-versions.json"),
+    )
+
+  private def readManifest(path: Path): VersionManifest =
+    VersionManifest.fromJson(new String(Files.readAllBytes(path), StandardCharsets.UTF_8)).toOption.get
+
+  "DownloadOrchestrator.run" should "update the manifest only for subjects that downloaded successfully" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    when(client.getByVersion("good", 1, false)).thenReturn(schemaEntity("good", 1, """{"type":"string"}"""))
+    when(client.getByVersion("bad", 1, false)).thenThrow(new IOException("boom"))
+
+    val cfg     = config(dir, Seq(RegistrySubject("good", 1), RegistrySubject("bad", 1)))
+    val summary = DownloadOrchestrator.run(client, cfg, testLogger)
+
+    summary.map(_.succeeded) shouldBe Right(1)
+    summary.map(_.skipped) shouldBe Right(0)
+    summary.map(_.failed.map(_._1.name)) shouldBe Right(List("bad"))
+
+    Files.exists(cfg.targetFolder.resolve("good-1.avsc")) shouldBe true
+    Files.exists(cfg.targetFolder.resolve("bad-1.avsc")) shouldBe false
+    readManifest(cfg.manifestFile).versions shouldBe Map("good" -> 1)
+  }
+
+  it should "skip a pinned subject already recorded at that version and never fetch it" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    // Any fetch of a subject that should have been skipped surfaces as a failure, not a skip.
+    when(client.getByVersion(anyString(), anyInt(), anyBoolean())).thenThrow(new IllegalStateException("must not fetch"))
+    val cfg    = config(dir, Seq(RegistrySubject("cached", 2)))
+    Files.createDirectories(cfg.manifestFile.getParent)
+    Files.write(cfg.manifestFile, VersionManifest(Map("cached" -> 2)).toJson.getBytes(StandardCharsets.UTF_8))
+
+    val summary = DownloadOrchestrator.run(client, cfg, testLogger)
+
+    summary.map(_.skipped) shouldBe Right(1)
+    summary.map(_.succeeded) shouldBe Right(0)
+    summary.map(_.failed) shouldBe Right(Nil)
+  }
+
+  it should "re-download everything and warn when the manifest is corrupted" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    when(client.getByVersion("svc", 1, false)).thenReturn(schemaEntity("svc", 1, """{"type":"int"}"""))
+
+    val cfg = config(dir, Seq(RegistrySubject("svc", 1)))
+    Files.createDirectories(cfg.manifestFile.getParent)
+    Files.write(cfg.manifestFile, "not json at all".getBytes(StandardCharsets.UTF_8))
+
+    val logger  = testLogger
+    val summary = DownloadOrchestrator.run(client, cfg, logger)
+
+    summary.map(_.succeeded) shouldBe Right(1)
+    verify(logger).warn("Version manifest corrupted, re-downloading all schemas")
+    readManifest(cfg.manifestFile).versions shouldBe Map("svc" -> 1)
+  }
+
+  it should "fail fast with Left when a subject pattern is an invalid regex" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    val cfg    = config(dir, Seq.empty).copy(patterns = Seq("["))
+
+    val result = DownloadOrchestrator.run(client, cfg, testLogger)
+
+    result.isLeft shouldBe true
+    result.left.get shouldBe a[DownloadError.InvalidPattern]
+  }
+
+  it should "download all subjects without touching the manifest when incremental is disabled" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    val meta   = new SchemaMetadata(1, 9, "AVRO", Collections.emptyList(), """{"type":"long"}""")
+    when(client.getLatestSchemaMetadata("svc")).thenReturn(meta)
+
+    val cfg     = config(dir, Seq(RegistrySubject.latest("svc"))).copy(incremental = false)
+    val summary = DownloadOrchestrator.run(client, cfg, testLogger)
+
+    summary.map(_.succeeded) shouldBe Right(1)
+    Files.exists(cfg.targetFolder.resolve("svc-9.avsc")) shouldBe true
+    Files.exists(cfg.manifestFile) shouldBe false
+  }
+}

--- a/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
@@ -105,6 +105,18 @@ class DownloadOrchestratorSpec extends AnyFlatSpec with Matchers with MockitoSug
     readManifest(cfg.manifestFile).versions shouldBe Map("dup" -> 1)
   }
 
+  it should "return Left for an out-of-range parallelism without touching the registry" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    val cfg    = config(dir, Seq(RegistrySubject("x", 1))).copy(parallelism = 99)
+    DownloadOrchestrator.run(client, cfg, testLogger).left.get shouldBe a[DownloadError.InvalidParallelism]
+  }
+
+  it should "return Left for an out-of-range retry count" in withTempDir { dir =>
+    val client = mock[SchemaRegistryClient]
+    val cfg    = config(dir, Seq(RegistrySubject("x", 1))).copy(retries = -1)
+    DownloadOrchestrator.run(client, cfg, testLogger).left.get shouldBe a[DownloadError.InvalidRetryConfig]
+  }
+
   it should "fail fast with Left when a subject pattern is an invalid regex" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     val cfg    = config(dir, Seq.empty).copy(patterns = Seq("["))

--- a/src/test/scala/org/galaxio/avro/EitherOpsSpec.scala
+++ b/src/test/scala/org/galaxio/avro/EitherOpsSpec.scala
@@ -1,0 +1,33 @@
+package org.galaxio.avro
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EitherOpsSpec extends AnyFlatSpec with Matchers {
+
+  "EitherOps.sequence" should "collect all Rights preserving order" in {
+    EitherOps.sequence(List(Right(1), Right(2), Right(3))) shouldBe Right(List(1, 2, 3))
+  }
+
+  it should "return Right(Nil) for an empty list" in {
+    EitherOps.sequence(List.empty[Either[String, Int]]) shouldBe Right(Nil)
+  }
+
+  it should "short-circuit to the first Left in input order" in {
+    EitherOps.sequence(List(Right(1), Left("a"), Right(2), Left("b"))) shouldBe Left("a")
+  }
+
+  "EitherOps.traverse" should "map each element and collect in order" in {
+    EitherOps.traverse(List("1", "2", "3"))(s => Right(s.toInt)) shouldBe Right(List(1, 2, 3))
+  }
+
+  it should "stop evaluating f after the first Left" in {
+    var calls  = 0
+    val result = EitherOps.traverse(List(1, 2, 3, 4)) { n =>
+      calls += 1
+      if (n == 2) Left(s"boom-$n") else Right(n)
+    }
+    result shouldBe Left("boom-2")
+    calls shouldBe 2 // f evaluated for 1 and 2 only, then short-circuits
+  }
+}

--- a/src/test/scala/org/galaxio/avro/RetryPolicySpec.scala
+++ b/src/test/scala/org/galaxio/avro/RetryPolicySpec.scala
@@ -111,4 +111,35 @@ class RetryPolicySpec extends AnyFlatSpec with Matchers with MockitoSugar {
     result shouldBe Left(fetchFailed)
     calls shouldBe 1
   }
+
+  "RetryPolicy.delayMs" should "grow exponentially with the backoff multiplier" in {
+    val policy = RetryPolicy(initialDelayMs = 100, backoffMultiplier = 2.0)
+    policy.delayMs(1) shouldBe 100L // 100 * 2^0
+    policy.delayMs(2) shouldBe 200L // 100 * 2^1
+    policy.delayMs(3) shouldBe 400L // 100 * 2^2
+    policy.delayMs(4) shouldBe 800L // 100 * 2^3
+  }
+
+  it should "stay constant when the multiplier is 1.0" in {
+    val policy = RetryPolicy(initialDelayMs = 50, backoffMultiplier = 1.0)
+    policy.delayMs(1) shouldBe 50L
+    policy.delayMs(2) shouldBe 50L
+    policy.delayMs(3) shouldBe 50L
+  }
+
+  it should "support fractional multipliers, truncating to whole millis" in {
+    val policy = RetryPolicy(initialDelayMs = 100, backoffMultiplier = 1.5)
+    policy.delayMs(1) shouldBe 100L // 100 * 1.5^0
+    policy.delayMs(2) shouldBe 150L // 100 * 1.5^1
+    policy.delayMs(3) shouldBe 225L // 100 * 1.5^2
+  }
+
+  it should "actually back off between retries (observable elapsed time)" in {
+    // initial=20, mult=2 → delays 20+40+80 = 140ms; exponential, not linear (which would be 60ms).
+    val policy    = RetryPolicy(maxRetries = 3, initialDelayMs = 20, backoffMultiplier = 2.0)
+    val started   = System.nanoTime()
+    policy.execute(Left(fetchFailed), "backoff-subject", testLogger)
+    val elapsedMs = (System.nanoTime() - started) / 1000000L
+    elapsedMs should be >= 140L
+  }
 }

--- a/src/test/scala/org/galaxio/avro/SubjectInfoSpec.scala
+++ b/src/test/scala/org/galaxio/avro/SubjectInfoSpec.scala
@@ -17,11 +17,7 @@ class SubjectInfoSpec extends AnyFlatSpec with Matchers {
     SubjectInfo("s", List(1, 2, 3, 4, 5), None).versionRange shouldBe "1..5"
   }
 
-  "SubjectInfo.latestVersion" should "be the last version" in {
-    SubjectInfo("s", List(1, 2, 5), None).latestVersion shouldBe Some(5)
-  }
-
-  it should "be None when there are no versions" in {
-    SubjectInfo("s", Nil, None).latestVersion shouldBe None
+  it should "be 'first..last' for exactly two versions" in {
+    SubjectInfo("s", List(1, 2), None).versionRange shouldBe "1..2"
   }
 }

--- a/src/test/scala/org/galaxio/avro/SubjectListingSpec.scala
+++ b/src/test/scala/org/galaxio/avro/SubjectListingSpec.scala
@@ -10,20 +10,20 @@ class SubjectListingSpec extends AnyFlatSpec with Matchers {
   private val listing =
     SubjectListing(List(info("user-value"), info("order-value"), info("payment-value")))
 
-  "SubjectListing.matching" should "keep case-insensitive substring matches" in {
-    listing.matching("ORDER").subjects.map(_.name) shouldBe List("order-value")
+  "SubjectListing.nameMatches" should "match case-insensitively" in {
+    SubjectListing.nameMatches("order-value", "ORDER") shouldBe true
   }
 
   it should "match a substring appearing anywhere in the name" in {
-    listing.matching("value").subjects should have size 3
+    SubjectListing.nameMatches("payment-value", "value") shouldBe true
   }
 
-  it should "return all subjects for an empty filter" in {
-    listing.matching("").subjects should have size 3
+  it should "match everything for an empty filter" in {
+    SubjectListing.nameMatches("anything", "") shouldBe true
   }
 
-  it should "return empty when nothing matches" in {
-    listing.matching("nope").subjects shouldBe empty
+  it should "not match when the substring is absent" in {
+    SubjectListing.nameMatches("user-value", "nope") shouldBe false
   }
 
   "SubjectListing.size" should "report the number of subjects" in {


### PR DESCRIPTION
Global polish pass after the recent feature additions (parallel downloads, incremental skip, reference resolution, list-subjects). One correctness fix, two production refactors, dead-code removal, and a test-quality overhaul. Public sbt keys and task behavior unchanged.

## Production changes

- **fix: write downloaded schemas as UTF-8** — `Downloader.writeSchema` used the platform-default charset (`body.getBytes()`) while every other read/write path uses UTF-8; non-ASCII schema content could corrupt on a non-UTF-8 JVM.
- **fix: join downloaded version by subject, not by name** — `DownloadOrchestrator` keyed the version lookup by subject name only; with divergent pinned versions of one subject (possible via reference resolution), a succeeded download could be recorded under the wrong version in the manifest. Now keyed by the full `RegistrySubject`. Regression-tested.
- **refactor: extract `DownloadOrchestrator`** — moved ~120 lines of orchestration (pattern resolution → reference expansion → incremental planning → bounded-parallel download → manifest update) out of the sbt task into a unit-testable object returning a `DownloadSummary`. The task is now thin settings→config→result wiring.
- **refactor: centralize config validation** — `DownloadOrchestrator.validate(cfg)` returns the first range violation; `run` short-circuits to `Left`, and the plugin reuses it to fail fast before opening a client.
- **refactor: extract `EitherOps.sequence/traverse`** — collapsed three hand-rolled `foldLeft`-over-`Either` into one shared, short-circuiting combinator.
- **refactor: drop dead code** — `SubjectInfo.latestVersion` and `SubjectListing.matching` had no production callers (tests repointed to the surviving `nameMatches` predicate).

## Test changes

- **Prove parallelism, don't count it** — concurrency tests asserted only result counts (a sequential run passes identically). `BoundedParallelSpec` now uses a deterministic `CountDownLatch` barrier (high-water == parallelism) + a bound gauge, replacing a flaky timing margin; a new `ConcurrencyProbe` client proxy lets the integration tests assert N downloads were in flight at once end-to-end.
- **Strengthen under-asserting ITs** — reference tests read `getReferences` back; non-Avro downloads assert body content (`include`, tolerant of registry normalization); reference resolution pins the exact expansion + versions + parsed content; partial-failure pins outcome by subject; compatibility checks assert verdict detail.
- **Thin IT duplication** — removed ~13 registry-free / duplicate scenarios, each owned by a named unit spec; the IT layer keeps one wiring check per behavior.
- **Shared `SchemaRegistryContainerSuite`** — extracted the ~30-line container boot duplicated across all 8 IT specs into one trait, with a teardown guard (ScalaTest skips `afterAll` when `beforeAll` throws) and centralized client close.

## Decision worth noting

The shared container trait boots **one registry per spec, not a module-wide singleton**: `SubjectExplorerIntegrationSpec` asserts the exact global subject list and `SubjectResolverIntegrationSpec` registers overlapping `*User*`/`*-value` subjects, so a shared registry would leak subjects across specs and break those assertions (and would force serial suites + namespace isolation). Per-spec boot keeps every assertion valid.

## Verification

`scalafmtCheckAll` clean · `compile` clean · **unit 186** · **it/test 40** (8 suites) · one scripted download test (`download-incremental`) green end-to-end through the new orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)