### PR TITLE
docs: auto-include AGENTS.md in CLAUDE.md via @ import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,12 @@ jobs:
         # hook-source-generators are intentional — they prove the plugin
         # correctly fails the build when the registry is unreachable.
         #
-        # sbt-2 axis: per-fixture gating is auto-detected — any fixture whose
-        # project/plugins.sbt adds an external sbt plugin (anything other than this
-        # plugin, e.g. download-success -> sbt-avrohugger 2.17.0) is skipped until
-        # that plugin ships an sbt-2 build. All other fixtures run on both axes.
+        # sbt-2 axis: per-fixture gating. A fixture is skipped on sbt 2.x if either
+        #   (a) it contains an `sbt2-skip` marker file (an sbt-2-incompatible build pattern,
+        #       e.g. overriding `Compile / compile` which needs Def.uncached on sbt 2), or
+        #   (b) its project/plugins.sbt adds an external sbt plugin other than this one
+        #       (e.g. download-success -> sbt-avrohugger 2.17.0) with no sbt-2 build yet.
+        # All other fixtures run on both axes.
         run: |
           set -euo pipefail
           if [ "${{ matrix.scala }}" = "2.12.21" ]; then
@@ -107,6 +109,10 @@ jobs:
           else
             FIXTURES=$(for d in src/sbt-test/schema-registry/*/; do
               n=$(basename "$d")
+              if [ -f "${d}sbt2-skip" ]; then
+                echo "skip sbt-2 scripted: $n (sbt2-skip marker)" >&2
+                continue
+              fi
               pf="${d}project/plugins.sbt"
               ext=""
               if [ -f "$pf" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
   scripted:
     name: Scripted (sbt ${{ matrix.sbt }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # Each fixture boots its own Kafka + Schema Registry containers (~45s each) across ~27 fixtures;
+    # the sbt-2 leg also compiles fixture metabuilds with Scala 3. 20 min is too tight once the
+    # suite runs per-axis. (Follow-up: shard fixtures across parallel jobs to cut wall-clock.)
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,35 +31,52 @@ jobs:
       - run: sbt scalafmtCheckAll scalafmtSbtCheck
 
   test:
-    name: Test
+    name: Test (Scala ${{ matrix.scala }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # 2.12.21 -> sbt 1.x artifact (_2.12_1.0); 3.8.4 -> sbt 2.x artifact (_sbt2_3)
+        scala: ['2.12.21', '3.8.4']
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: ./.github/actions/sbt-setup
       - name: Compile
-        run: sbt compile
+        run: sbt "++${{ matrix.scala }}" compile
       - name: Test
-        run: sbt test
+        run: sbt "++${{ matrix.scala }}" test
 
   it-test:
-    name: Integration Test
+    name: Integration Test (Scala ${{ matrix.scala }})
     runs-on: ubuntu-24.04
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        scala: ['2.12.21', '3.8.4']
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: ./.github/actions/sbt-setup
       - name: Integration Test
-        run: sbt it/test
+        run: sbt "++${{ matrix.scala }}" it/test
 
   scripted:
-    name: Scripted (plugin e2e)
+    name: Scripted (sbt ${{ matrix.sbt }})
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scala: '2.12.21'
+            sbt: '1.x'
+          - scala: '3.8.4'
+            sbt: '2.x'
     env:
       # Testcontainers boots from sbt's meta-build classloader, where strategy
       # ServiceLoader discovery finds no socket strategy. Point it at the daemon
@@ -75,4 +92,32 @@ jobs:
         # [error] lines in the log from download-failure, hook-compile, and
         # hook-source-generators are intentional — they prove the plugin
         # correctly fails the build when the registry is unreachable.
-        run: sbt scripted
+        #
+        # sbt-2 axis: per-fixture gating is auto-detected — any fixture whose
+        # project/plugins.sbt adds an external sbt plugin (anything other than this
+        # plugin, e.g. download-success -> sbt-avrohugger 2.17.0) is skipped until
+        # that plugin ships an sbt-2 build. All other fixtures run on both axes.
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.scala }}" = "2.12.21" ]; then
+            sbt "++2.12.21" scripted
+          else
+            FIXTURES=$(for d in src/sbt-test/schema-registry/*/; do
+              n=$(basename "$d")
+              pf="${d}project/plugins.sbt"
+              ext=""
+              if [ -f "$pf" ]; then
+                ext=$(grep -E 'addSbtPlugin' "$pf" | grep -v 'sbt-schema-registry-plugin' || true)
+              fi
+              if [ -n "$ext" ]; then
+                echo "skip sbt-2 scripted: $n (external sbt-1-only plugin)" >&2
+                continue
+              fi
+              printf 'schema-registry/%s ' "$n"
+            done)
+            if [ -z "$FIXTURES" ]; then
+              echo "ERROR: all sbt-2 scripted fixtures were filtered out — gating misconfigured" >&2
+              exit 1
+            fi
+            sbt "++3.8.4" "scripted $FIXTURES"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,11 @@ jobs:
 
       - uses: ./.github/actions/sbt-setup
 
-      - name: Compile & test
+      - name: Compile & test (both axes)
         # Integration tests (it/test) and scripted tests run in ci.yml on PRs
         # before merge — no need to re-run with Docker during release.
-        run: sbt compile test
+        # `+` cross-builds across crossScalaVersions (2.12 -> sbt 1.x, 3 -> sbt 2.x).
+        run: sbt +compile +test
 
       - name: Publish to Maven Central via sbt-ci-release
         env:
@@ -50,6 +51,8 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        # `ci-release` runs `+publishSigned`, so a single tag cross-publishes BOTH
+        # artifacts under one version: _2.12_1.0 (sbt 1.x) and _sbt2_3 (sbt 2.x).
         run: sbt ci-release
 
       - name: Generate release notes

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,18 +1,21 @@
 <!--
 Sync Impact Report
 ===================
-Version change: 0.0.0 → 1.0.0 (initial ratification)
-Modified principles: N/A (initial creation)
-Added sections:
-  - Core Principles (5 principles)
-  - Technical Constraints
-  - Development Workflow
-  - Governance
+Version change: 1.0.0 → 1.1.0 (MINOR — materially expanded guidance; no principle removed or redefined)
+Modified principles:
+  - I. Backward Compatibility — added the additive-build-axis invariant (cross-build must not disturb existing artifacts)
+  - V. Format and Verify Before Commit — made fatal-warnings axis-aware (-Xfatal-warnings on 2.12, -Werror on 3) and
+       sanctioned narrowly-scoped -Wconf suppressions for cross-version-unavoidable deprecations
+Modified sections:
+  - Technical Constraints — now dual-axis (Scala 2.12 / sbt 1.x and Scala 3.x / sbt 2.x); records dual published artifacts
+  - Development Workflow — verify commands cross both axes
+Added sections: N/A
 Removed sections: N/A
 Templates requiring updates:
-  - .specify/templates/plan-template.md — ✅ compatible (Constitution Check section aligns)
-  - .specify/templates/spec-template.md — ✅ compatible (requirements/scenarios structure aligns)
-  - .specify/templates/tasks-template.md — ✅ compatible (phase structure supports test-first + parallel)
+  - .specify/templates/plan-template.md — ✅ compatible (Constitution Check section is generic; no mandatory section change)
+  - .specify/templates/spec-template.md — ✅ compatible (requirements/scenarios structure unaffected)
+  - .specify/templates/tasks-template.md — ✅ compatible (phase structure still supports test-first + parallel)
+  - AGENTS.md — ✅ already reflects the dual-axis build/test/release flow (updated in feature 009-sbt2-cross-build)
 Follow-up TODOs: none
 -->
 
@@ -26,6 +29,10 @@ All published sbt keys, task names, and public API surface MUST remain
 backward-compatible. Breaking changes require a major version bump,
 migration documentation, and explicit user approval before implementation.
 
+Adding a new build or runtime target (e.g. a second sbt/Scala axis) MUST be
+additive: every existing published artifact keeps its coordinates, keys,
+types, and observable behavior unchanged. A new axis only adds a new artifact.
+
 Rationale: This is a published sbt plugin consumed by external users.
 Unexpected breakage erodes trust and blocks downstream builds.
 
@@ -37,6 +44,10 @@ subjects as a sealed ADT, `DownloadError` models failures as `Either`,
 `SchemaRegistryAuth` handles credentials. Dependencies MUST be injected,
 never constructed internally.
 
+sbt-version-only API differences (e.g. `Def.uncached`) MUST be isolated
+behind a single compatibility seam (`PluginCompat`, in version-specific
+source directories), keeping the shared source tree free of axis branching.
+
 Rationale: Clear ownership makes the codebase navigable and testable.
 Injected dependencies enable unit testing without real infrastructure.
 
@@ -47,6 +58,10 @@ without external services. Integration tests (`sbt it/test`) use
 Testcontainers with real Schema Registry + Kafka. Plugin end-to-end tests
 (`sbt scripted`) validate sbt task behavior. NEVER mock Schema Registry
 HTTP where a real integration path exists.
+
+When the project is cross-built, the unit and integration suites MUST pass
+on every supported axis, and the e2e (scripted) suite MUST run on each axis
+for every fixture whose dependencies resolve there.
 
 Rationale: Real-service tests caught regressions that mocks would miss.
 The three-tier test strategy covers unit logic, protocol correctness,
@@ -60,6 +75,9 @@ automated publishing via `sbt-ci-release`. Version numbers MUST NOT be
 reused. Release tags MUST NOT be deleted after deployment starts. Patch
 releases cherry-pick fixes from `main` onto release branches.
 
+A single version tag MUST cross-publish all axes under one version number
+(no per-axis version divergence).
+
 Rationale: Tag-driven releases with CI automation eliminate manual
 publishing errors. Sonatype Central permanently rejects duplicate
 versions, so reuse causes irrecoverable failures.
@@ -67,28 +85,49 @@ versions, so reuse causes irrecoverable failures.
 ### V. Format and Verify Before Commit
 
 `scalafmtAll` and `scalafmtSbt` MUST pass before every commit. CI runs
-`scalafmtCheckAll scalafmtSbtCheck compile test` on every PR. Code MUST
-compile with `-Xfatal-warnings` — no warnings tolerated.
+`scalafmtCheckAll scalafmtSbtCheck +compile +test` on every PR, across all
+supported axes. Code MUST compile with fatal warnings enabled on every axis
+(`-Xfatal-warnings` on Scala 2.12, `-Werror` on Scala 3) — no warnings
+tolerated.
+
+The only permitted warning suppressions are narrowly-scoped `-Wconf` rules
+for deprecations that have no single source form accepted by all supported
+Scala versions (e.g. `_` type wildcards, `: _*` vararg splices). Each such
+rule MUST be message-scoped (not category- or file-wide) and carry a comment
+explaining why a shared-source fix is impossible.
 
 Rationale: Consistent formatting eliminates review noise. Fatal warnings
-prevent gradual quality erosion.
+prevent gradual quality erosion; scoping the unavoidable cross-version
+deprecations keeps the gate strict without forking source per axis.
 
 ## Technical Constraints
 
-- **Language**: Scala 2.12 (sbt's Scala version — not project Scala)
-- **Build tool**: sbt 1.12.x with autoplugin API
+- **Language**: Cross-built from one source tree — Scala 2.12 (sbt 1.x axis)
+  and Scala 3.x (sbt 2.x axis). These are sbt's Scala versions, not a
+  consumer's project Scala.
+- **Build tool**: sbt 1.x (1.12.x) and sbt 2.x (2.0.0), via `crossScalaVersions`
+  + `pluginCrossBuild / sbtVersion` keyed on the Scala binary version. The
+  autoplugin API is used on both axes.
+- **Published artifacts**: `_2.12_1.0` (sbt 1.x) and `_sbt2_3` (sbt 2.x),
+  cross-published from a single tag under one version.
 - **Runtime dependency**: Confluent `kafka-schema-registry-client`
 - **Test stack**: ScalaTest + mockito-scala (unit), Testcontainers (integration), sbt scripted (e2e)
 - **Java**: 17+
 - **License**: Apache 2.0
 - **Publishing**: Maven Central via sbt-ci-release + Sonatype
 - **New dependencies or major upgrades**: MUST be approved before adding
+- **Axis versions** (`scala3`, `sbt2`) are bumped manually and pinned exactly
+  (never `<latest>`/snapshot); `scala3` MUST match the Scala version the
+  targeted sbt 2.x ships.
 
 ## Development Workflow
 
 1. Branch from `main` for all work
 2. Format: `sbt scalafmtAll scalafmtSbt`
-3. Verify: `sbt compile test` (unit), `sbt it/test` (integration, requires Docker), `sbt scripted` (e2e)
+3. Verify both axes: `sbt +compile +test` (unit), `sbt +it/test` (integration,
+   requires Docker), and scripted e2e per axis — `sbt ++2.12.21 scripted` plus
+   `sbt ++3.8.4 "scripted <fixtures>"` (the sbt-2 axis skips fixtures that pull
+   sbt-1-only external plugins until those plugins publish sbt-2 builds)
 4. Rebase-only merge strategy — no merge commits in PR branches
 5. Never force-push or commit directly to `main`
 6. Never commit broken code or do opportunistic refactors outside scope
@@ -113,4 +152,4 @@ with a documented rationale.
 
 Runtime development guidance lives in `AGENTS.md` at repository root.
 
-**Version**: 1.0.0 | **Ratified**: 2026-06-14 | **Last Amended**: 2026-06-14
+**Version**: 1.1.0 | **Ratified**: 2026-06-14 | **Last Amended**: 2026-06-22

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,17 @@ Principal Engineer: Scala 2.12, sbt plugin API, Confluent Schema Registry, Avro.
 
 ## Stack
 
-Scala 2.12 (sbt's Scala), sbt 1.x, Java 17+. Exact dependency versions in `build.sbt` / `project/Dependencies.scala`.
+Cross-built from one source tree for two axes: **Scala 2.12 → sbt 1.x** (artifact `_2.12_1.0`) and **Scala 3.8.x → sbt 2.x** (artifact `_sbt2_3`). Java 17+. Axis mapping in `build.sbt` (`crossScalaVersions` + `pluginCrossBuild / sbtVersion`); dependency versions in `project/Dependencies.scala`. sbt-version-only API differences (e.g. `Def.uncached`) live behind `PluginCompat` in `src/main/scala-2.12` / `src/main/scala-3`; almost all code is shared in `src/main/scala`.
 
 ## Source Layout
 
 ```
-src/main/scala/org/galaxio/avro/    # plugin core + domain
-src/test/scala/org/galaxio/avro/    # unit tests (mock client via mockito-scala)
-it/src/test/scala/org/galaxio/avro/ # integration tests (Testcontainers — real Schema Registry + Kafka)
-src/sbt-test/                       # scripted e2e tests (sbt plugin test framework)
+src/main/scala/org/galaxio/avro/        # plugin core + domain (shared by both axes)
+src/main/scala-2.12/org/galaxio/avro/   # PluginCompat seam — sbt-1 axis (Def.uncached no-op)
+src/main/scala-3/org/galaxio/avro/      # PluginCompat seam — sbt-2 axis (Def.uncached native)
+src/test/scala/org/galaxio/avro/        # unit tests (mock client via mockito-scala)
+it/src/test/scala/org/galaxio/avro/     # integration tests (Testcontainers — real Schema Registry + Kafka)
+src/sbt-test/                           # scripted e2e tests (sbt plugin test framework)
 ```
 
 ## Commands
@@ -24,10 +26,13 @@ src/sbt-test/                       # scripted e2e tests (sbt plugin test framew
 ```bash
 pre-commit install                                         # install git hook (one-time)
 sbt scalafmtAll scalafmtSbt                               # format
-sbt scalafmtCheckAll scalafmtSbtCheck compile test        # verify
-sbt compile test                                          # CI (unit only)
-sbt it/test                                               # integration (Docker required)
-sbt scripted                                              # sbt plugin e2e
+sbt scalafmtCheckAll scalafmtSbtCheck +compile +test      # verify both axes
+sbt +compile +test                                        # CI unit, both axes
+sbt ++3.8.4 compile test                                  # sbt-2 / Scala-3 axis only
+sbt ++2.12.21 compile test                               # sbt-1 / Scala-2.12 axis only
+sbt +it/test                                             # integration both axes (Docker required)
+sbt ++2.12.21 scripted                                   # sbt-1 plugin e2e (all fixtures)
+sbt ++3.8.4 "scripted schema-registry/<fixture>"         # sbt-2 e2e (skip sbt-1-only-plugin fixtures, e.g. download-success)
 ```
 
 ## Public sbt Keys (compatibility-sensitive — never rename/retype/remove)
@@ -83,6 +88,7 @@ Trunk-based with release branches. `v*` tags trigger sbt-ci-release to Sonatype 
 
 ### Rules
 
+- **One tag cross-publishes both axes** — `sbt ci-release` (`+publishSigned`) emits both `_2.12_1.0` (sbt 1.x) and `_sbt2_3` (sbt 2.x) from a single `vX.Y.Z` tag, under the same version number
 - **Every minor version gets its own `release/X.Y.0` branch** — no exceptions
 - **Tags ONLY on `release/*` branches or `main`** — release.yml validates this
 - **Branch name must match tag version**: `release/1.2.0` → `v1.2.0`, `v1.2.1`, etc.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-Use AGENTS.md as the primary repository instruction file for this project.
+@AGENTS.md
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@ Use AGENTS.md as the primary repository instruction file for this project.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/008-list-subjects-task/plan.md
+at specs/009-sbt2-cross-build/plan.md
 <!-- SPECKIT END -->

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,55 @@
 import Dependencies.*
 
-val sbtV = "1.12.12"
+// Cross-build axes (one shared source tree, two published artifacts):
+//   sbt 1.x consumer -> Scala 2.12 -> pluginCrossBuild sbtVersion 1.12.12 -> artifact _2.12_1.0
+//   sbt 2.x consumer -> Scala 3    -> pluginCrossBuild sbtVersion 2.0.0   -> artifact _sbt2_3
+// NOTE: these axis versions are bumped manually — scala-steward does not track plain vals.
+// `scala3` must match the Scala version the targeted sbt 2.x ships (see its release notes); bump both together.
+val scala212 = "2.12.21"
+val scala3   = "3.8.4" // the Scala 3 version sbt 2.0.0 is built against
+
+val sbt1 = "1.12.12"
+val sbt2 = "2.0.0"
+
+// Map the active Scala binary version to the sbt line it targets. Kept as a helper so the
+// plugin's pluginCrossBuild target and the it-module's util-logging version stay decoupled (D8).
+// Any Scala 2.x (incl. a future 2.13) routes to sbt 1.x and reuses the src/main/scala-2.12 PluginCompat
+// seam; adding 2.13-specific compat code would require a new src/main/scala-2.13 source tree.
+def sbtLineFor(scalaBinVersion: String): String =
+  if (scalaBinVersion.startsWith("2.")) sbt1 else sbt2
+
+// Both axes compile under -Xfatal-warnings (no warnings tolerated). Scala 3 emits a different warning
+// set, so two syntax deprecations from Java-interop reflection in Registrar.scala (`_` type wildcards
+// and `args: _*` vararg splices) — which are valid/required on 2.12 but have no single form accepted by
+// both — are scoped away with targeted -Wconf on the Scala 3 axis only (D13). Everything else stays fatal.
+def scalacOptionsFor(scalaBinVersion: String): Seq[String] = {
+  val base = Seq("-encoding", "UTF-8", "-deprecation", "-feature", "-unchecked")
+  if (scalaBinVersion.startsWith("2."))
+    base ++ Seq(
+      "-Xfatal-warnings", // Scala 2.12 spelling; on Scala 3 this is a deprecated alias of -Werror
+      "-language:implicitConversions",
+      "-language:higherKinds",
+      "-language:existentials",
+      "-language:postfixOps",
+    )
+  else
+    base ++ Seq(
+      "-Werror", // Scala 3 spelling of fatal warnings
+      "-language:implicitConversions",
+      "-language:higherKinds",
+      "-language:postfixOps",
+      // -language:existentials intentionally omitted — Scala 3 enables it by default (2.12 still needs the flag).
+      "-Wconf:msg=is deprecated for wildcard arguments:s",
+      "-Wconf:msg=is no longer supported for vararg:s",
+    )
+}
 
 lazy val commonSettings = Seq(
-  scalaVersion := "2.12.21",
-  scalacOptions ++= Seq(
-    "-encoding",
-    "UTF-8",
-    "-Xfatal-warnings",
-    "-deprecation",
-    "-feature",
-    "-unchecked",
-    "-language:implicitConversions",
-    "-language:higherKinds",
-    "-language:existentials",
-    "-language:postfixOps",
-  ),
+  scalaVersion       := scala212,
+  crossScalaVersions := Seq(scala212, scala3),
+  scalacOptions      := scalacOptionsFor(scalaBinaryVersion.value),
+  // scala-collection-compat backports scala.jdk to 2.12 only; Scala 3 has it in the stdlib, so don't ship it there.
+  libraryDependencies ++= (if (scalaBinaryVersion.value.startsWith("2.")) Seq(collectionCompat) else Seq.empty),
 )
 
 lazy val sbtSchemaRegistryPlugin = (project in file("."))
@@ -24,7 +58,7 @@ lazy val sbtSchemaRegistryPlugin = (project in file("."))
   .settings(
     name                          := "sbt-schema-registry-plugin",
     sbtPlugin                     := true,
-    pluginCrossBuild / sbtVersion := sbtV,
+    pluginCrossBuild / sbtVersion := sbtLineFor(scalaBinaryVersion.value),
     resolvers ++= Seq("Confluent" at "https://packages.confluent.io/maven/"),
     libraryDependencies ++= Seq(
       schemaRegistryClient,
@@ -46,7 +80,7 @@ lazy val it = (project in file("it"))
     publish / skip := true,
     Test / fork    := true,
     libraryDependencies ++= Seq(
-      "org.scala-sbt"    %% "util-logging" % sbtV % Test,
+      "org.scala-sbt"    %% "util-logging" % sbtLineFor(scalaBinaryVersion.value) % Test,
       scalatest           % Test,
       testcontainersKafka % Test,
       protobufProvider    % Test,

--- a/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/DownloaderIntegrationSpec.scala
@@ -3,6 +3,7 @@ package org.galaxio.avro
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.client.rest.entities.{SchemaReference => ConfluentSchemaReference}
 import org.apache.avro.Schema
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sbt.util.Logger
@@ -67,7 +68,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with SchemaReg
   it should "return Left with SchemaFetchFailed for missing subject" in withFixture { (_, downloader) =>
     val result = downloader.schemaSubjectToFile(RegistrySubject("does-not-exist", 1))
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
+    result.left.value shouldBe a[DownloadError.SchemaFetchFailed]
   }
 
   it should "return Left with SchemaFetchFailed for missing version of existing subject" in withFixture { (_, downloader) =>
@@ -78,7 +79,7 @@ class DownloaderIntegrationSpec extends AnyFlatSpec with Matchers with SchemaReg
 
     val result = downloader.schemaSubjectToFile(RegistrySubject(subject, 99))
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
+    result.left.value shouldBe a[DownloadError.SchemaFetchFailed]
   }
 
   it should "produce identical output files across two downloads" in withTempDir { dir =>

--- a/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ParallelDownloaderIntegrationSpec.scala
@@ -2,6 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.apache.avro.Schema
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sbt.util.Logger
@@ -62,7 +63,7 @@ class ParallelDownloaderIntegrationSpec extends AnyFlatSpec with Matchers with S
 
     val bySubject = results.map { case (s, r) => s.name -> r }.toMap
     bySubject("nonexistent-subject") shouldBe a[Left[_, _]]
-    bySubject("nonexistent-subject").left.get shouldBe a[DownloadError.SchemaFetchFailed]
+    bySubject("nonexistent-subject").left.value shouldBe a[DownloadError.SchemaFetchFailed]
     bySubject("test-subject-1") shouldBe a[Right[_, _]]
     bySubject("test-subject-3") shouldBe a[Right[_, _]]
 

--- a/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala
@@ -9,7 +9,7 @@ import sbt.util.Logger
 
 import java.nio.file.{Files, Path}
 import java.util.Collections
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** End-to-end reference resolution against a real Confluent Schema Registry.
   *

--- a/it/src/test/scala/org/galaxio/avro/SchemaRegistryContainerSuite.scala
+++ b/it/src/test/scala/org/galaxio/avro/SchemaRegistryContainerSuite.scala
@@ -30,15 +30,15 @@ trait SchemaRegistryContainerSuite extends BeforeAndAfterAll { self: Suite =>
   /** Identity-cache capacity for the spec-facing client (was hard-coded to 100 in every spec). */
   protected def clientCacheSize: Int = 100
 
-  @volatile private var network: Network               = _
-  @volatile private var kafka: ConfluentKafkaContainer = _
-  @volatile private var sr: JGenericContainer[_]       = _
+  @volatile private var network: Network               = null.asInstanceOf[Network]
+  @volatile private var kafka: ConfluentKafkaContainer = null.asInstanceOf[ConfluentKafkaContainer]
+  @volatile private var sr: JGenericContainer[_]       = null.asInstanceOf[JGenericContainer[_]]
 
   /** Base URL of the booted Schema Registry, e.g. `http://localhost:32785`. */
-  protected var registryUrl: String = _
+  protected var registryUrl: String = null.asInstanceOf[String]
 
   /** A client connected to [[registryUrl]]; usable from `registerSubjects()` and the tests. */
-  protected var registryClient: CachedSchemaRegistryClient = _
+  protected var registryClient: CachedSchemaRegistryClient = null.asInstanceOf[CachedSchemaRegistryClient]
 
   /** Override to seed subjects/fixtures once the registry and client are up. No-op by default. */
   protected def registerSubjects(): Unit = ()

--- a/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/SubjectExplorerIntegrationSpec.scala
@@ -2,6 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.apache.avro.Schema
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -40,7 +41,7 @@ class SubjectExplorerIntegrationSpec extends AnyFlatSpec with Matchers with Sche
     val result = SubjectExplorer.listAll(registryClient, None)
 
     result shouldBe a[Right[_, _]]
-    val listing = result.right.get
+    val listing = result.value
     listing.subjects.map(_.name) shouldBe List(orderSubject, userSubject)
 
     // Real getAllVersions over the two registered Order versions and the single User version.
@@ -50,7 +51,7 @@ class SubjectExplorerIntegrationSpec extends AnyFlatSpec with Matchers with Sche
   }
 
   it should "surface a subject-level compatibility override and report None for subjects without one" in {
-    val listing = SubjectExplorer.listAll(registryClient, None).right.get
+    val listing = SubjectExplorer.listAll(registryClient, None).value
     listing.subjects.find(_.name == orderSubject).get.compatibility shouldBe Some("BACKWARD")
     listing.subjects.find(_.name == userSubject).get.compatibility shouldBe None
   }

--- a/it/src/test/scala/org/galaxio/avro/SubjectResolverIntegrationSpec.scala
+++ b/it/src/test/scala/org/galaxio/avro/SubjectResolverIntegrationSpec.scala
@@ -2,6 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.apache.avro.Schema
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -29,7 +30,7 @@ class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with Sche
     val result = SubjectResolver.resolve(registryClient, specs)
 
     result shouldBe a[Right[_, _]]
-    val names = result.right.get.subjects.map(_.name)
+    val names = result.value.subjects.map(_.name)
     names should contain theSameElementsAs List("com.myorg.User-value", "com.myorg.Order-value")
   }
 
@@ -46,7 +47,7 @@ class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with Sche
     val result = SubjectResolver.resolve(registryClient, specs)
 
     result shouldBe a[Right[_, _]]
-    val plan    = result.right.get
+    val plan    = result.value
     val userSub = plan.subjects.find(_.name == "com.myorg.User-value")
     userSub shouldBe Some(RegistrySubject.Pinned("com.myorg.User-value", 1))
     plan.subjects.count(_.name == "com.myorg.User-value") shouldBe 1
@@ -66,7 +67,7 @@ class SubjectResolverIntegrationSpec extends AnyFlatSpec with Matchers with Sche
     val result = SubjectResolver.resolve(registryClient, specs)
 
     result shouldBe a[Right[_, _]]
-    result.right.get.subjects.map(_.name) should contain theSameElementsAs List(
+    result.value.subjects.map(_.name) should contain theSameElementsAs List(
       "com.myorg.User-value",
       "internal.Audit-value",
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,13 +2,19 @@ import sbt.*
 
 object Dependencies {
   private object Versions {
-    val schReqClient   = "8.2.2"
-    val scalatest      = "3.2.20"
-    val mockito        = "2.2.1"
-    val testcontainers = "1.21.4"
+    val schReqClient     = "8.2.2"
+    val scalatest        = "3.2.20"
+    val mockito          = "2.2.1"
+    val testcontainers   = "1.21.4"
+    val collectionCompat = "2.14.0"
   }
 
   lazy val schemaRegistryClient: ModuleID = "io.confluent" % "kafka-schema-registry-client" % Versions.schReqClient
+
+  // Backports `scala.jdk.CollectionConverters` to Scala 2.12 (no-op on Scala 3, which has it in stdlib),
+  // so a single cross-compatible import compiles on both the sbt-1 (2.12) and sbt-2 (3) axes.
+  lazy val collectionCompat: ModuleID =
+    "org.scala-lang.modules" %% "scala-collection-compat" % Versions.collectionCompat
 
   lazy val scalatest: ModuleID    = "org.scalatest" %% "scalatest"               % Versions.scalatest
   lazy val mockitoScala: ModuleID = "org.mockito"   %% "mockito-scala-scalatest" % Versions.mockito

--- a/specs/009-sbt2-cross-build/checklists/requirements.md
+++ b/specs/009-sbt2-cross-build/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Cross-build for sbt 2.x
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a build/tooling feature, so some unavoidable platform nouns (sbt 1.x / 2.x, Scala 2.12 / 3) appear in the spec — they are the *product surface* (which artifact a consumer resolves), not implementation choices. The concrete build mechanism (crossScalaVersions, pluginCrossBuild, source dirs) is confined to the Assumptions section as planning input, keeping requirements and success criteria outcome-focused.
+- Feasibility was grounded in the two authoritative sbt 2.x migration docs and verified against Maven Central artifact metadata; the central claims (cross-build is supported; Scala 3 is additive, not a 2.12 replacement; util-logging is the one hard resolution blocker) survived adversarial verification.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/009-sbt2-cross-build/contracts/cross-build.md
+++ b/specs/009-sbt2-cross-build/contracts/cross-build.md
@@ -1,0 +1,41 @@
+# Contract: Cross-build & publish
+
+**Feature**: [../spec.md](../spec.md) · **Date**: 2026-06-22
+
+The build/release contract for the dual-axis plugin. Realizes FR-001, FR-002, FR-005, FR-006, FR-008, FR-010, FR-011.
+
+## Axis → artifact mapping
+
+| Consumer | Scala | sbt API | pluginCrossBuild sbtVersion | Published coordinate |
+|----------|-------|---------|----------------------------|----------------------|
+| sbt 1.x build | 2.12.21 | 1.x | `1.12.12` | `sbt-schema-registry-plugin_2.12_1.0` |
+| sbt 2.x build | 3.8.4 | 2.x | sbt 2.0.0 (latest GA) | `sbt-schema-registry-plugin_sbt2_3` |
+
+`crossScalaVersions := Seq("2.12.21", "3.8.x")`; `pluginCrossBuild / sbtVersion` selects the sbt target by `scalaBinaryVersion`. Both built from one shared source tree (FR-005).
+
+## Build commands (contract)
+
+| Intent | Command (cross-aware) |
+|--------|----------------------|
+| compile both axes | `sbt +compile` |
+| unit-test both axes | `sbt +test` |
+| integration both axes | `sbt +it/test` (Docker required) |
+| scripted, sbt-1 | `sbt ++2.12.21 scripted` |
+| scripted, sbt-2 (gated fixtures) | `sbt ++3.8.x scripted` |
+| format gate | `sbt scalafmtCheckAll scalafmtSbtCheck` |
+| single-axis compile (debug) | `sbt ++3.8.x compile` |
+
+## Publish contract (D12)
+
+- A single `v*` tag triggers `sbt-ci-release` in cross form (`+publishSigned` aggregate) → emits **both** coordinates under one version number.
+- Same version number across both coordinates; no per-axis divergence (Constitution IV).
+- `release.yml` change to cross-publish requires owner approval ("ask first: release workflow changes").
+- Tags only on `release/*` or `main`; never reuse a version; never delete a deployed tag (Constitution IV, AGENTS.md).
+
+## Invariants
+
+1. The sbt-1 / `_2.12_1.0` artifact's coordinates, version scheme, keys, and behavior are unchanged by this feature (FR-002, US2).
+2. All pinned versions are exact; no `<latest>`/snapshot resolution (FR-010).
+3. `util-logging`'s version is decoupled from the plugin's `pluginCrossBuild / sbtVersion` literal (FR-006, D8).
+4. CI compiles + tests both axes and fails if either regresses (FR-008, SC-005).
+5. Scripted on sbt-2 covers every fixture without an sbt-1-only external plugin; external-plugin fixtures are explicitly axis-gated (FR-007, D10).

--- a/specs/009-sbt2-cross-build/contracts/plugin-api.md
+++ b/specs/009-sbt2-cross-build/contracts/plugin-api.md
@@ -1,0 +1,46 @@
+# Contract: Public sbt key surface (frozen — both axes)
+
+**Feature**: [../spec.md](../spec.md) · **Date**: 2026-06-22
+
+This is the backward-compatibility contract (Constitution I, FR-003, SC-004). Every key below MUST keep its **exact name, type, and observable semantics on both the sbt-1 (Scala 2.12) and sbt-2 (Scala 3) axes**. Cross-build is purely additive — nothing here may be renamed, retyped, removed, or change default/behavior.
+
+## Task keys — `taskKey[Unit]`
+
+| Key | Semantics (identical on both axes) |
+|-----|-----------------------------------|
+| `schemaRegistryDownload` | download schemas from registry → writes files to target folder |
+| `schemaRegistryRegister` | register (push) schemas to registry |
+| `schemaRegistryTestCompatibility` | check schema compatibility against registry |
+| `schemaRegistryListSubjects` | list registry subjects with versions + compatibility |
+
+**Side-effect guarantee (new, sbt-2 axis)**: each task performs its real side effect on **every** invocation; sbt 2.x task-result caching MUST NOT skip it (FR-004, via the `PluginCompat.uncached` seam, D7). Observable behavior matches the sbt-1 axis.
+
+## Setting keys — `settingKey[T]`
+
+| Key | Type | Default | Frozen |
+|-----|------|---------|--------|
+| `schemaRegistryUrl` | `String` | `"http://localhost:8081"` | ✓ |
+| `schemaRegistryTargetFolder` | `File` | `sourceDirectory/main/avro` | ✓ |
+| `schemaRegistrySubjects` | `Seq[RegistrySubject]` | `Seq()` | ✓ |
+| `schemaRegistryRegistrations` | `Seq[RegistryRegistration]` | `Seq()` | ✓ |
+| `schemaRegistryCacheSize` | `Int` | `Downloader.defaultCacheSize` | ✓ |
+| `schemaRegistryAuth` | `Option[SchemaRegistryAuth]` | `None` | ✓ |
+| `schemaRegistryProperties` | `Map[String, String]` | `Map.empty` | ✓ |
+| `schemaRegistrySubjectPatterns` | `Seq[String]` | `Seq()` | ✓ |
+| `schemaRegistryIncremental` | `Boolean` | `true` | ✓ |
+| `schemaRegistryParallelism` | `Int` | `4` | ✓ |
+| `schemaRegistryRetries` | `Int` | `3` | ✓ |
+| `schemaRegistryResolveReferences` | `Boolean` | `true` | ✓ |
+| `schemaRegistrySubjectFilter` | `Option[String]` | `None` | ✓ |
+
+**Note on `schemaRegistryTargetFolder: File`**: stays `sbt.File` on both axes. If sbt 2.x ever forces the `File`→`xsbti.HashedVirtualFileRef` change for this setting, it is absorbed behind the `PluginCompat` seam (D4) so the *public type the user sets* remains `File`. Not expected to be needed.
+
+## Public domain types (referenced by keys — unchanged)
+
+`RegistrySubject` (sealed ADT: Pinned/Latest), `RegistryRegistration`, `SchemaRegistryAuth`. These compile identically on Scala 2.12 and Scala 3 (sealed-trait ADTs need no `enum` conversion). No signature changes.
+
+## Verification
+
+- Public-key-surface review (manual diff) confirms zero renames/retypes/removals (D14, SC-004).
+- Scripted e2e on the sbt-1 axis stays green unchanged (D14, US2).
+- A fresh sbt-2 project resolves these keys at their documented defaults and runs all four tasks with identical observable results (US1, SC-001).

--- a/specs/009-sbt2-cross-build/data-model.md
+++ b/specs/009-sbt2-cross-build/data-model.md
@@ -1,0 +1,68 @@
+# Phase 1 Data Model: Cross-build for sbt 2.x
+
+**Feature**: [spec.md](spec.md) · **Date**: 2026-06-22
+
+This feature has **no application data model** — it changes how the plugin is built, tested, and published, not what it computes. The "entities" below are build/release artifacts and configuration constructs. The plugin's runtime domain types (`RegistrySubject`, `DownloadError`, `SubjectInfo`, …) are unchanged and must compile identically on both axes.
+
+## Build/Release Entities
+
+### CrossAxis
+The (Scala version → sbt version) pairing that selects which artifact a consumer resolves and which API the plugin compiles against.
+
+| Field | sbt-1 axis | sbt-2 axis |
+|-------|-----------|-----------|
+| `scalaVersion` | `2.12.21` | `3.8.x` (e.g. `3.8.4`, pinned) |
+| `scalaBinaryVersion` | `2.12` | `3` |
+| `pluginCrossBuild / sbtVersion` | `1.12.12` | `2.0.0` (latest GA) |
+| compiled-against sbt API | sbt 1.x | sbt 2.x |
+| `PluginCompat` seam dir | `src/main/scala-2.12/` | `src/main/scala-3/` |
+
+**Rules**: `crossScalaVersions := Seq("2.12.21", "3.8.x")`; the sbtVersion mapping is keyed on `scalaBinaryVersion` (D1). The two axes are independent build steps over one shared source tree.
+
+### PublishedArtifact
+A coordinate emitted by a release. One version tag emits both (D12).
+
+| Field | sbt-1 artifact | sbt-2 artifact |
+|-------|---------------|----------------|
+| coordinate suffix | `_2.12_1.0` | `_sbt2_3` |
+| consumer | sbt 1.x builds | sbt 2.x builds |
+| version number | shared (one `v*` tag) | shared (same tag) |
+| compatibility | unchanged from today | new |
+
+**Rules**: same version number across both coordinates (Constitution IV — no version reuse, no divergent per-axis numbers). Both must resolve from the release repository (SC-003).
+
+### PluginCompat seam
+A per-axis shim object unifying the handful of sbt-2-only APIs behind a stable signature.
+
+| Member | sbt-1 (`scala-2.12/`) | sbt-2 (`scala-3/`) |
+|--------|----------------------|--------------------|
+| `uncached[A](a: => A): A` | `a` (identity) | `Def.uncached(a)` |
+
+**Rules**: shared code references only `PluginCompat.*`; never calls `Def.uncached` directly. Added only because `Def.uncached` is sbt-2-only (D7). Extend with a `FileRef` bridge only if the `File`↔`HashedVirtualFileRef` difference ever bites (D4 — not expected).
+
+### DependencyVersionMap
+Per-axis version selection for Scala-versioned dependencies that differ across axes.
+
+| Dependency | sbt-1 axis | sbt-2 axis | Notes |
+|-----------|-----------|-----------|-------|
+| `org.scala-sbt %% util-logging` (it) | 1.12.x line | `2.0.0` line | **decoupled** from plugin `sbtV` (D8) |
+| `scala-collection-compat` | added (backports `scala.jdk`) | present/no-op | enables shared `scala.jdk` import (D5) |
+| `scalatest` | `3.2.20` | `3.2.20` (`_3`) | same version, both axes |
+| `mockito-scala-scalatest` | `2.2.1` | `2.2.1` (`_3`) | inline-macro caveat (D9) |
+| confluent `*`, testcontainers | unchanged | unchanged | Java-only, no Scala axis |
+
+**Rules**: `util-logging`'s version MUST NOT reuse the plugin's `pluginCrossBuild / sbtVersion` literal (D8). Pin exact versions; never resolve `<latest>` (FR-010).
+
+### ScriptedFixture
+An e2e test project under `src/sbt-test/`. Gains an axis-eligibility attribute (D10).
+
+| Field | Value |
+|-------|-------|
+| `externalPluginDeps` | e.g. sbt-avrohugger, testcontainers, or none |
+| `eligibleAxes` | `{sbt-1, sbt-2}` if no sbt-1-only external dep; `{sbt-1}` otherwise |
+
+**Rules**: a fixture runs scripted on an axis only if all its external plugins have a build for that axis. External-plugin fixtures are explicitly gated, never silently skipped (SC-005).
+
+## State / lifecycle
+
+Single transition for the repository: **single-axis (sbt-1 only) → dual-axis (sbt-1 + sbt-2)**, additive. The sbt-1 artifact never changes coordinates or behavior across the transition (FR-002, US2). No per-request or runtime state is introduced.

--- a/specs/009-sbt2-cross-build/plan.md
+++ b/specs/009-sbt2-cross-build/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Cross-build for sbt 2.x (add a Scala 3 axis)
+
+**Branch**: `009-sbt2-cross-build` | **Date**: 2026-06-22 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/009-sbt2-cross-build/spec.md`
+
+## Summary
+
+Make the published plugin usable from **sbt 2.x** builds while leaving today's **sbt 1.x** users untouched. sbt 2.x runs all plugins on Scala 3 (3.8.x), so this is an **additive second build axis**, not a migration off Scala 2.12: one shared source tree cross-builds to a `_2.12_1.0` artifact (sbt 1.x) and a `_sbt2_3` artifact (sbt 2.x). The mechanism is sbt's `crossScalaVersions` + a `pluginCrossBuild / sbtVersion` mapping keyed on `scalaBinaryVersion` (D1; needs sbt ≥ 1.10.2, satisfied at 1.12.12). The plugin's sbt API surface is unchanged by sbt 2.x, so the work is dominated by (a) a few cross-compatible source fixes the strict `-Xfatal-warnings` flag forces (`JavaConverters`→`scala.jdk`, `Either` projections→`EitherValues`), (b) wrapping the four side-effecting tasks so sbt 2.x's default task caching can't silently skip their I/O (`PluginCompat.uncached` seam), (c) repinning the `it` module's `util-logging` per axis (the one hard resolution blocker), and (d) a CI matrix + single-tag cross-publish. Per clarification: publish `_sbt2_3` now against the latest sbt 2.x GA (2.0.0); gate scripted per-fixture by axis; one `v*` tag emits both coordinates.
+
+## Technical Context
+
+**Language/Version**: Scala 2.12.21 (sbt-1 axis) **and** Scala 3.8.x — e.g. 3.8.4, pinned exactly (sbt-2 axis)
+
+**Primary Dependencies**: Confluent `kafka-schema-registry-client` 8.2.2 + protobuf/json providers (Java, no Scala axis); `org.scala-sbt %% util-logging` (axis-tracked: 1.12.x line on sbt-1, `2.0.0` on sbt-2 — decoupled from plugin `sbtV`, D8); test: ScalaTest 3.2.20 (`_3` ✓), mockito-scala-scalatest 2.2.1 (`_3` ✓, inline-macro caveat D9); new build dep: `scala-collection-compat` (backports `scala.jdk` to 2.12, D5 — owner approval per "ask first: new deps")
+
+**Build tool**: build-side sbt 1.12.12; cross-targets sbt 1.x (1.12.12) and sbt 2.x (2.0.0, latest GA)
+
+**Storage**: N/A (build/release tooling; reads a remote Schema Registry at task runtime, no local persistence)
+
+**Testing**: unit (`+test`, both axes), integration (`+it/test`, Testcontainers, both axes), scripted (`scripted`, per-fixture axis-gated, D10)
+
+**Target Platform**: JVM (Java 17+); the plugin runs inside both sbt 1.x and sbt 2.x builds
+
+**Project Type**: Single published sbt plugin, cross-built (one project + `it/` integration subproject)
+
+**Performance Goals**: N/A (build-time tooling; no latency/throughput target)
+
+**Constraints**: `-Xfatal-warnings` on released builds, both axes (Constitution V; transiently relaxed via `-Wconf` only during migration, D13); backward compatibility of the `_2.12_1.0` artifact and all public keys (Constitution I); exact version pins, no `<latest>` (FR-010); single `v*` tag emits both coordinates under one version (Constitution IV)
+
+**Scale/Scope**: ~6 source-fix files (JavaConverters), ~56 test sites (`Either`), 4 task-body wraps, 1 `PluginCompat` seam (2 tiny per-axis files), `build.sbt` + `project/Dependencies.scala` cross config, CI workflow matrix, `release.yml` cross-publish, scripted-fixture axis gating. No public API change.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 and re-checked after Phase 1.*
+
+| Principle | Assessment | Status |
+|---|---|---|
+| I. Backward Compatibility | Purely additive: `_2.12_1.0` artifact, all key names/types/defaults/semantics unchanged (contracts/plugin-api.md). New axis only adds the `_sbt2_3` artifact. No major bump needed (sbt-1 users unaffected). | ✅ PASS |
+| II. Single Responsibility | No responsibility changes. New `PluginCompat` seam owns exactly the sbt-version API differences (uncached, optional FileRef); dependencies still injected. | ✅ PASS |
+| III. Test-First | Same three tiers, now matrixed over both axes; tests/fixtures authored/updated before the cross config flips green. mockito specs mock pure-logic collaborators only — no Schema Registry HTTP mocking (D9). | ✅ PASS |
+| IV. Trunk-Based Release | Single `v*` tag cross-publishes both coordinates under one version (no reuse, no divergence); tags on `release/*`/`main`. `release.yml` cross-publish change requires owner approval ("ask first"). | ✅ PASS (with owner sign-off on release.yml) |
+| V. Format & Verify | Released builds keep `-Xfatal-warnings` on both axes; the migration-time `-Wconf` relaxation is a transient scaffold removed before merge — end state has zero tolerated warnings; CI gate stays strict. | ✅ PASS |
+
+**Result**: PASS — no unjustified violations. Complexity Tracking not required. Two boundary call-outs (not violations): the new `scala-collection-compat` dependency (D5) and the `release.yml` cross-publish edit (D12) both touch "ask first" boundaries → require owner approval during implementation.
+
+*Post-Phase-1 re-check*: Design adds no new project, no cross-class responsibility bleed, no public-API break, no runtime dependency on the sbt-1 axis. The `PluginCompat` seam is the minimal construct needed for sbt-version divergence. Still PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-sbt2-cross-build/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions D1–D14
+├── data-model.md        # Phase 1 — build/release entities
+├── quickstart.md        # Phase 1 — validation scenarios V1–V6
+├── contracts/
+│   ├── plugin-api.md     # Phase 1 — frozen public sbt key surface (backward-compat contract)
+│   └── cross-build.md    # Phase 1 — axis→artifact map, build commands, publish contract
+├── checklists/
+│   └── requirements.md   # spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 — created by /speckit-tasks (NOT here)
+```
+
+### Source Code (repository root)
+
+```text
+build.sbt                           # MODIFY: crossScalaVersions := Seq("2.12.21","3.8.x");
+                                    #         pluginCrossBuild/sbtVersion mapping by scalaBinaryVersion;
+                                    #         decouple it-module util-logging version per axis (D8);
+                                    #         add scala-collection-compat (D5); -Wconf migration scoping (D13)
+project/
+├── build.properties               # unchanged (build-side sbt 1.12.12)
+└── Dependencies.scala             # MODIFY: util-logging axis-version helper; scala-collection-compat;
+                                    #         keep confluent/testcontainers (Java) as-is
+
+src/main/scala/org/galaxio/avro/
+├── *.scala (shared)               # MODIFY 5 files: JavaConverters → scala.jdk.CollectionConverters (D5)
+│                                  #   (Downloader, SubjectExplorer, SubjectResolver,
+│                                  #    CompatibilityChecker, VersionManifest)
+└── SchemaDownloaderPlugin.scala   # MODIFY: wrap 4 task bodies in PluginCompat.uncached{} (D7)
+
+src/main/scala-2.12/org/galaxio/avro/
+└── PluginCompat.scala             # NEW: uncached = identity (sbt-1 axis seam, D4/D7)
+
+src/main/scala-3/org/galaxio/avro/
+└── PluginCompat.scala             # NEW: uncached = Def.uncached (sbt-2 axis seam, D4/D7)
+
+src/test/scala/org/galaxio/avro/
+└── *Spec.scala                    # MODIFY: 56 Either projection sites → EitherValues (D6);
+                                    #   if mock[T] inline error on Scala 3, refactor 8 mock specs (D9)
+
+it/src/test/scala/org/galaxio/avro/
+└── ReferenceResolutionIntegrationSpec.scala  # MODIFY: JavaConverters → scala.jdk (D5)
+
+src/sbt-test/                       # MODIFY: per-fixture axis gating (D10); fixtures pulling
+                                    #   sbt-1-only externals (sbt-avrohugger) stay sbt-1
+
+.github/workflows/
+├── ci.yml                         # MODIFY: Scala-axis matrix (2.12, 3.8.x): compile+test+it; scripted gated (D11)
+└── release.yml                    # MODIFY (owner approval): single v* tag → cross +publishSigned both coords (D12)
+
+AGENTS.md                          # MODIFY: stack/commands/release describe dual-axis flow (FR-011)
+```
+
+**Structure Decision**: Single cross-built plugin. ~All source stays in the shared `src/main/scala/`; the only per-axis source is the two-file `PluginCompat` seam under `scala-2.12/` and `scala-3/`, selected automatically by sbt per cross step (D4). The `it` module and scripted fixtures need no source split — their axis differences live in build config (util-logging version) and fixture gating respectively.
+
+## Complexity Tracking
+
+> No Constitution violations requiring justification. The `scala-collection-compat` dependency and `release.yml` edit are owner-approval boundary items, not complexity violations — tracked in tasks, not here.
+
+## Phase notes
+
+- **Phase 0 (research.md)**: complete — D1–D14 resolve mechanism, versions, source layout, the three spec-deferred items (source-dir D4, mockito D9, backward-compat verification D14), and the one hard blocker (util-logging D8). No `NEEDS CLARIFICATION` remain.
+- **Phase 1 (this run)**: data-model.md (build/release entities), contracts/ (frozen key surface + cross-build/publish contract), quickstart.md (V1–V6 + migration smoke-order). Agent context (`CLAUDE.md` SPECKIT markers) updated to point here.
+- **Phase 2**: `/speckit-tasks` will derive the dependency-ordered task list. Suggested spine: forward-compatible source fixes first (D5, D6 — land on current 2.12 build), then the `PluginCompat` seam + task wraps (D7), then util-logging decoupling (D8), then the cross config (D1), then CI matrix (D11) and cross-publish (D12), with `-Xfatal-warnings` re-enabled before merge (D13).

--- a/specs/009-sbt2-cross-build/quickstart.md
+++ b/specs/009-sbt2-cross-build/quickstart.md
@@ -1,0 +1,72 @@
+# Quickstart / Validation Guide: Cross-build for sbt 2.x
+
+**Feature**: [spec.md](spec.md) · **Date**: 2026-06-22
+
+Runnable scenarios proving the dual-axis build works end-to-end. Maps to Success Criteria. See [contracts/cross-build.md](contracts/cross-build.md) for commands and [contracts/plugin-api.md](contracts/plugin-api.md) for the frozen key surface.
+
+## Prerequisites
+
+- Build-side sbt 1.12.12 (≥ 1.10.2 required for the cross mapping).
+- JDK 17+.
+- Docker running (integration scenarios only).
+- sbt 2.0.0 GA pinned in the build (D3).
+
+## V1 — sbt 1.x consumer unaffected  *(SC-002, SC-004, US2)*
+
+1. Take an existing sbt 1.x consumer build pinned to the previous plugin version.
+2. Bump **only** the plugin version to the cross-built release.
+3. Reload and run each task.
+
+**Expected**: build resolves `…_2.12_1.0`; all four tasks behave exactly as before; no other build change required.
+
+## V2 — sbt 2.x consumer, fresh project  *(SC-001, US1)*
+
+1. Create a scratch project pinned to sbt 2.x.
+2. Add the plugin; set `schemaRegistryUrl` and one `schemaRegistrySubjects` entry.
+3. Run `schemaRegistryDownload`.
+
+**Expected**: plugin's `…_sbt2_3` artifact resolves and applies; the schema file is written to the target folder; output matches the sbt-1 result.
+
+## V3 — Side effects not skipped by sbt-2 caching  *(SC-006, FR-004, D7)*
+
+1. On the sbt-2 project from V2, run `schemaRegistryDownload` twice in a row (no input change).
+
+**Expected**: **both** runs perform the real download (file written/refreshed both times); the second run is NOT silently skipped by task-result caching. Implemented via the `PluginCompat.uncached` seam.
+
+## V4 — Cross-compile both axes  *(FR-005)*
+
+```
+sbt +compile
+```
+
+**Expected**: compiles for Scala 2.12 (sbt 1.x) and Scala 3.8.x (sbt 2.x) from one checkout, with `-Xfatal-warnings` clean on both (D5, D6, D13).
+
+## V5 — Test matrix both axes  *(SC-005, FR-007, FR-008)*
+
+```
+sbt +test            # unit, both axes
+sbt +it/test         # integration, both axes (Docker)
+sbt ++2.12.21 scripted     # scripted, sbt-1: all fixtures
+sbt ++3.8.x   scripted     # scripted, sbt-2: fixtures without sbt-1-only externals
+```
+
+**Expected**: unit + integration green on both axes; scripted green on sbt-1 for all fixtures and on sbt-2 for non-external fixtures; external-plugin fixtures (e.g. sbt-avrohugger) explicitly gated to sbt-1, not silently skipped (D10).
+
+## V6 — Single-tag cross-publish  *(SC-003, FR-011, D12)*
+
+1. Dry-run the release path (or inspect a real `v*` tag run) with cross-publish enabled.
+
+**Expected**: one version tag produces **both** `…_2.12_1.0` and `…_sbt2_3` under one version number; both resolve from the release repository.
+
+## Migration smoke-order (local, during implementation)
+
+Recommended order to keep the build iterable (mirrors research D5→D8):
+
+1. `scala.collection.JavaConverters` → `scala.jdk.CollectionConverters` + add `scala-collection-compat` (D5).
+2. Test `Either` projections → `EitherValues` (D6).
+3. Add the `PluginCompat` seam + wrap the four tasks in `PluginCompat.uncached` (D7).
+4. Decouple + repin `util-logging` per axis (D8).
+5. Add `crossScalaVersions` + `pluginCrossBuild / sbtVersion` mapping (D1); relax `-Xfatal-warnings` via `-Wconf` while iterating, then re-enable (D13).
+6. Wire CI matrix (D11) and the cross-publish release step (D12).
+
+Steps 1–2 are forward-compatible and can land on the current 2.12 build first with zero downside.

--- a/specs/009-sbt2-cross-build/research.md
+++ b/specs/009-sbt2-cross-build/research.md
@@ -1,0 +1,128 @@
+# Phase 0 Research: Cross-build for sbt 2.x
+
+**Feature**: [spec.md](spec.md) · **Date**: 2026-06-22
+
+All decisions below were grounded in the two authoritative sbt 2.x migration docs
+([migrating-from-sbt-1.x](https://www.scala-sbt.org/2.x/docs/en/changes/migrating-from-sbt-1.x.html),
+[sbt-2.0-change-summary](https://www.scala-sbt.org/2.x/docs/en/changes/sbt-2.0-change-summary.html))
+and verified against Maven Central artifact metadata. Each central claim survived an adversarial verification pass.
+
+---
+
+## D1 — Cross-build mechanism
+
+**Decision**: sbt 1.x-side `crossScalaVersions` + a `pluginCrossBuild / sbtVersion` mapping keyed on `scalaBinaryVersion` (2.12 → sbt 1.x, Scala 3 → sbt 2.x). Build-side sbt stays 1.12.12.
+
+**Rationale**: Requires sbt ≥ 1.10.2; the project is on 1.12.12, so it's available. Lighter than `projectMatrix` for a single-plugin repo and does **not** force relocating `src/` into a `plugin/` subdirectory (which `projectMatrix`'s automatic cross-build needs to keep the synthetic root from also picking up sources). The migration doc states verbatim: *"if you cross build an sbt plugin with Scala 3.x and 2.12.x, it will automatically cross build against sbt 1.x and sbt 2.x."*
+
+**Alternatives considered**: `projectMatrix` with `.jvmPlatform(scalaVersions = Seq("3.8.4","2.12.21"))` — rejected: forces `plugin/` subdir relocation and is heavier than needed here. Real-world precedent: sbt-assembly 2.3.x cross-builds via this exact mechanism; 60+ plugins already ported.
+
+## D2 — Scala 3 version for the sbt-2 axis
+
+**Decision**: Pin an exact Scala **3.8.x** (currently **3.8.4**) — the version sbt 2.x mandates.
+
+**Rationale**: The sbt 2.0 change summary: *"build.sbt DSL … is based on Scala 3.x (currently 3.8.4)."* `<latest>` on Maven Central is a snapshot — never resolve it.
+
+**Alternatives considered**: Scala 3.3 LTS — **rejected, factually wrong**: 3.3 LTS was only an early proposal (sbt/sbt #7194), never the version sbt 2.x targets.
+
+## D3 — sbt 2.x target & publish timing  *(spec clarification Q1=A)*
+
+**Decision**: Target the latest sbt 2.x **GA** — sbt 2.0.0 — and publish `_sbt2_3` now. Pin the exact GA version (`sbt2 = 2.0.0`, `scala3 = 3.8.4`). sbt 2.0.0 reached final GA, so the earlier "a published RC is acceptable" hedge no longer applies; target GA.
+
+**Rationale**: sbt-assembly already publishes `_sbt2_3` against RCs; early adopters get a usable artifact. Pinning exactly keeps builds reproducible.
+
+**Alternatives considered**: Hold publish until sbt 2.0.0 final GA — rejected by clarification.
+
+## D4 — Source-directory layout
+
+**Decision**: Keep ~100% of code in shared `src/main/scala/`. Prefer cross-compatible **rewrites** (D5, D6) over version splits. Add `src/main/scala-2.12/` and `src/main/scala-3/` **only** as a thin `PluginCompat` seam for genuinely sbt-2-only API calls (realistically just `Def.uncached`, see D7). The `it` module and scripted fixtures need no source split.
+
+**Rationale**: sbt auto-appends `scala-<scalaBinaryVersion>` to the base `scala` dir per cross step, so the seam is selected automatically. The plugin's touched sbt API surface (`AutoPlugin`, `autoImport`, `taskKey`/`settingKey`, `streams.value`, slash syntax, `%` DSL) is unchanged by sbt 2.x — it uses none of the keys whose types changed (`URL→URI`, `licenses→Seq[License]`, `Classpath→HashedVirtualFileRef`), no `IntegrationTest`, no `useCoursier`. So a shim is likely unnecessary beyond task-caching.
+
+**Alternatives considered**: Split all six JavaConverters files into per-version dirs — rejected (dup, noise) in favor of the compat-lib rewrite (D5).
+
+## D5 — `scala.collection.JavaConverters` removal  *(blocker, 6 files)*
+
+**Decision**: Replace `import scala.collection.JavaConverters._` with `import scala.jdk.CollectionConverters._` in all 6 files (`VersionManifest`, `SubjectExplorer`, `Downloader`, `SubjectResolver`, `CompatibilityChecker` in main; `ReferenceResolutionIntegrationSpec` in `it`), and add `org.scala-lang.modules %% scala-collection-compat` so `scala.jdk.CollectionConverters` resolves on the **2.12** axis too.
+
+**Rationale**: `scala.collection.JavaConverters` is deprecated in Scala 3; under `-Xfatal-warnings` that's a hard compile error. `scala.jdk.CollectionConverters` is the canonical replacement but only ships in 2.13+/3 — `scala-collection-compat` backports it to 2.12, making the single import cross-compile. New dependency: standard, tiny, ubiquitous — but per the project's "ask first: new deps" boundary, confirm with the owner before adding.
+
+**Alternatives considered**: Per-version source dirs holding the old import on 2.12 and the new one on 3 — rejected (splits 6 files vs adding one well-known compat module).
+
+## D6 — `Either` `.right.get`/`.left.get` projections  *(blocker, 56 test sites)*
+
+**Decision**: Replace all 56 `.right.get`/`.left.get` projection sites in tests with scalatest `EitherValues` (`.value` / `.left.value`).
+
+**Rationale**: Scala 3's right-biased `Either` plus `-Xfatal-warnings` turns the deprecated projections into errors. `EitherValues` is version-agnostic, removes projection use entirely, and reads better. Main code uses `.left.map(...)` (LeftProjection, retained) — no change needed there.
+
+**Alternatives considered**: `either.toOption.get` / `either.swap.toOption.get` — rejected (noisier; loses scalatest's clear failure messages).
+
+## D7 — sbt 2.x task-result caching  *(behavioral blocker, 4 tasks)*
+
+**Decision**: Route the four side-effecting task bodies (`schemaRegistryDownload`, `schemaRegistryRegister`, `schemaRegistryTestCompatibility`, `schemaRegistryListSubjects`) through a `PluginCompat.uncached { … }` seam — `identity` on the sbt-1/2.12 axis, `Def.uncached(…)` on the sbt-2/Scala-3 axis. Verify with a double-run check (V3 in quickstart).
+
+**Rationale**: sbt 2.x caches all tasks by default and *silently skips side effects on a cache hit* — exactly this plugin's danger case (network I/O, file writes, registry pushes, returning `Unit`). `Def.uncached` is sbt-2-only, so it lives behind the `PluginCompat` seam (the one place D4's split is actually used). Keeps a single shared task body.
+
+**Alternatives considered**: Duplicate the four task defs into per-version dirs — rejected (dup). Making tasks return non-`Unit` cache keys — rejected (changes public behavior).
+
+## D8 — `util-logging` version coupling  *(the one hard resolution blocker)*
+
+**Decision**: In the `it` module, decouple `util-logging`'s version from the plugin's `sbtV` literal. Introduce a separate value selected by `scalaBinaryVersion`: sbt-1 axis → the 1.12.x line; sbt-2 axis → the sbt-2 line (e.g. `2.0.0`). The plugin's `pluginCrossBuild / sbtVersion` mapping stays independent.
+
+**Rationale**: `build.sbt:49` pins `org.scala-sbt %% util-logging % sbtV` with `sbtV = "1.12.12"`. There is **no `util-logging_3` at 1.12.x** — `util-logging_3` exists only at `2.0.0`. On the Scala 3 axis this requests a nonexistent artifact → hard unresolved-dependency error. The literal `sbtV` currently drives *both* the plugin's cross-build target and util-logging's version, so a naive bump moves the plugin's sbt target unintentionally — they must be decoupled.
+
+**Alternatives considered**: Drop `util-logging` from `it` — rejected (used by integration tests). Pin a single version — impossible (no version satisfies both axes).
+
+## D9 — mockito-scala on Scala 3  *(manageable caveat, not a blocker)*
+
+**Decision**: Keep `mockito-scala-scalatest 2.2.1` (its `_3` artifact resolves). First attempt: compile the 8 mock specs on Scala 3 unchanged. If the `mock[T]` macro fails (it requires inline call chains on Scala 3), refactor those call sites to be inline, or fall back to mockito-core directly for the affected specs. Budget this as a contingency, not a baseline.
+
+**Rationale**: Verified — `mockito-scala-scalatest_3 2.2.1` is published and cross-resolves cleanly; it is the sole `_3` version (no older fallback). The only Scala-3 concern is the inline-macro requirement. Affected specs (8): `RegistrarSpec`, `SubjectExplorerSpec`, `RetryPolicySpec`, `DownloadOrchestratorSpec`, `DownloaderSpec`, `CompatibilityCheckerSpec`, `SubjectResolverSpec`, `ParallelDownloaderSpec`. Constitution III (no HTTP mocking) is respected — these mock pure-logic collaborators, not Schema Registry HTTP.
+
+**Alternatives considered**: Swap the whole suite to mockito-core up front — rejected (premature; 2.2.1 may compile as-is).
+
+## D10 — Scripted per-fixture axis gating  *(spec clarification Q2=A)*
+
+**Decision**: `pluginCrossBuild` declares both sbt axes. Fixtures with **no** sbt-1-only external plugin run scripted on both axes; fixtures pulling sbt-1-only external plugins (e.g. sbt-avrohugger 2.17.0 in `download-success/`) stay sbt-1-gated until upstream ships sbt-2 builds. Verify upstream sbt-2 availability before requiring sbt-2 scripted on those. The sbt-2 release is never blocked by a third-party plugin.
+
+**Rationale**: 28 `plugins.sbt` fixtures already use migration-safe `addSbtPlugin(... % v)` + slash syntax. The only blockers are *external* plugins the repo doesn't control. Gating keeps the plugin's own e2e coverage on sbt-2 (via no-external fixtures) without hostage to upstream timelines.
+
+**Alternatives considered**: Drop scripted from the sbt-2 gate entirely (spec Q2 option C) — rejected by clarification. Hard-require full scripted on sbt-2 (option B) — rejected (blocks on sbt-avrohugger).
+
+## D11 — CI matrix
+
+**Decision**: GitHub Actions matrix over the Scala axis (2.12, 3.8.x). Each leg runs `compile`, `test`, and `it/test`; scripted runs per D10 gating. CI fails if either axis regresses (FR-008, SC-005). Keep the existing `scalafmtCheckAll scalafmtSbtCheck` gate.
+
+**Rationale**: Direct realization of FR-008/SC-005. Matrix legs map cleanly to `++ <scalaVersion>` cross steps.
+
+**Alternatives considered**: Single leg running `+test` (cross-aggregate) — workable but loses per-axis failure clarity and parallelism; matrix preferred.
+
+## D12 — Release / dual-artifact publish  *(spec clarification Q3=A)*
+
+**Decision**: A single `v*` tag cross-publishes both `_2.12_1.0` and `_sbt2_3` under one version number, via the existing tag-triggered `sbt-ci-release` flow run in its cross form (`+publishSigned` aggregate). Update `release.yml` to cross-publish.
+
+**Rationale**: sbt-ci-release honors `crossScalaVersions`, so one tag emits all cross artifacts. Preserves the one-tag-per-version model and avoids divergent version numbers across axes (Sonatype rejects duplicate versions permanently — Constitution IV). `release.yml` changes touch the "ask first: release workflow changes" boundary → require owner approval.
+
+**Alternatives considered**: Separate sbt-2 publish job (Q3 B) / manual publish (Q3 C) — rejected by clarification.
+
+## D13 — `-Xfatal-warnings` during migration
+
+**Decision**: Released builds keep `-Xfatal-warnings` on **both** axes (Constitution V, FR-009). During migration only, relax locally via `-Wconf` source-version scoping to iterate; remove the relaxation before merge. CI gate stays strict.
+
+**Rationale**: Scala 3 emits a different/larger warning set than 2.12, so the strict flag fails the build before you can iterate. The relaxation is a transient dev scaffold, not the end state — Constitution V's "no warnings tolerated" holds for merged/released code.
+
+**Alternatives considered**: Permanently relax `-Werror` on the Scala 3 axis — rejected (violates Constitution V).
+
+## D14 — Backward-compat verification for the 2.12 artifact
+
+**Decision**: Verify the sbt-1 artifact is unaffected via three checks, no new tooling: (a) the `_2.12_1.0` coordinates and version scheme are unchanged; (b) the full scripted suite on sbt-1 still passes; (c) a public-key-surface review confirms no key renamed/retyped/removed (SC-004). Defer MiMa.
+
+**Rationale**: This is a plugin (sbt-key surface), not a typical binary-compat library; scripted e2e + key-surface diff already cover the compatibility contract. MiMa adds setup cost for little marginal signal here.
+
+**Alternatives considered**: Add MiMa binary-compat checks — deferred (can add later if the public Scala API grows).
+
+---
+
+## Resolved unknowns
+
+No `NEEDS CLARIFICATION` markers remain. The three spec-deferred items are resolved: source-dir strategy (D4), mockito handling (D9), backward-compat verification (D14). Dependency Scala-3 availability is confirmed: scalatest 3.2.20 ✓, mockito-scala-scalatest 2.2.1 ✓ (sole `_3`), util-logging (axis-tracked) ✓; confluent + testcontainers are Java-only ✓.

--- a/specs/009-sbt2-cross-build/spec.md
+++ b/specs/009-sbt2-cross-build/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Cross-build for sbt 2.x (add a Scala 3 axis)
+
+**Feature Branch**: `009-sbt2-cross-build`
+
+**Created**: 2026-06-22
+
+**Status**: Draft
+
+**Input**: User request (RU): "настроить кроссбилд получится ли? нужно ли на 3 скалу переходить?" — Can we set up a cross-build, and do we need to migrate to Scala 3? Plus two sbt 2.x migration docs: [migrating-from-sbt-1.x](https://www.scala-sbt.org/2.x/docs/en/changes/migrating-from-sbt-1.x.html), [sbt-2.0-change-summary](https://www.scala-sbt.org/2.x/docs/en/changes/sbt-2.0-change-summary.html).
+
+## Feasibility Answer (Summary)
+
+Captured here because the request is a feasibility question, not only a feature ask:
+
+- **Cross-build is feasible.** sbt 2.x officially supports it. The migration doc states verbatim: *"if you cross build an sbt plugin with Scala 3.x and 2.12.x, it will automatically cross build against sbt 1.x and sbt 2.x."* This plugin's build is already migration-clean (slash syntax throughout, no legacy `<<=`/`in(Config)` syntax, none of the sbt keys whose types changed).
+- **Scala 3 is required, but as an ADDITIVE second axis — not a migration away from 2.12.** sbt 2.x runs all plugins on Scala 3 (currently **3.8.4**, not 3.3 LTS). The sbt 1.x consumer base keeps its existing Scala 2.12 artifact; we add a Scala 3 artifact for sbt 2.x. The same source tree serves both. "Additive" is at the build-configuration level — the Scala 3 axis still needs a small set of source fixes (see Risks).
+
+## Clarifications
+
+### Session 2026-06-22
+
+- Q: Scope — true dual cross-build (keep sbt 1.x **and** add sbt 2.x) or sbt 2.x only? → A: Dual cross-build. sbt 2.x is still pre/early-GA and dropping 2.12 would strand the entire current user base. Both artifacts published from one source tree.
+- Q: Which Scala 3 version for the sbt 2.x axis? → A: The version sbt 2.x mandates (Scala 3.8.x, currently 3.8.4) — pinned to an exact release, never read from a `<latest>`/snapshot tag.
+- Q: When to publish the `_sbt2_3` artifact — ship now against current sbt 2.x, or hold for GA? → A: Ship now against the latest sbt 2.x **GA** (sbt 2.0.0, the current release), pinned exactly. (sbt 2.0.0 reached final GA, so the original "ship even against an RC" hedge is moot — target GA.)
+- Q: Release gate for scripted e2e on the sbt-2 axis, given external fixture plugins may lack sbt-2 builds? → A: Gate scripted per-fixture by axis. Unit + integration must be green on both axes; scripted on sbt-2 is required only for fixtures with no sbt-1-only external plugins. Fixtures depending on sbt-1-only external plugins (e.g. sbt-avrohugger) stay sbt-1-gated until upstream ships sbt-2 builds — the sbt-2 release is never blocked by a third-party plugin's timeline.
+- Q: How are both artifacts published — one tag or a separate step? → A: One tag cross-publishes both. Extend the existing `v*`-tag-triggered sbt-ci-release to cross-publish so a single version number emits both `_2.12_1.0` and `_sbt2_3`. Preserves the one-tag-per-version model and avoids divergent version numbers across axes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - sbt 2.x project can apply the plugin and run every task (Priority: P1)
+
+A developer whose build has moved to sbt 2.x adds this plugin to their build. The plugin resolves (a Scala 3 artifact exists), applies cleanly, and all published tasks — download, register, test-compatibility, and list-subjects — run and produce the same observable results they do on sbt 1.x, including the actual side effects (files written to disk, schemas pushed to the registry).
+
+**Why this priority**: This is the entire point of the request. sbt 2.x users cannot use the plugin at all today, because no Scala 3 artifact is published. Without it there is no feature.
+
+**Independent Test**: From a scratch project pinned to sbt 2.x, add the plugin, configure a registry URL and one subject, run `schemaRegistryDownload`, and verify the schema file is written to the target folder (not silently skipped by task caching).
+
+**Acceptance Scenarios**:
+
+1. **Given** an sbt 2.x build that adds the plugin, **When** the build loads, **Then** the plugin's Scala 3 artifact resolves and the plugin applies with all setting keys available at their documented defaults.
+2. **Given** an sbt 2.x build with `schemaRegistrySubjects` configured, **When** the user runs `schemaRegistryDownload` twice in a row, **Then** both runs perform the real download work (the second run is not silently skipped by sbt 2.x task caching) and the target folder contains the expected schema files.
+3. **Given** an sbt 2.x build with `schemaRegistryRegistrations` configured, **When** the user runs `schemaRegistryRegister` and `schemaRegistryTestCompatibility`, **Then** schemas are pushed and compatibility is reported exactly as on sbt 1.x.
+4. **Given** an sbt 2.x build, **When** the user runs `schemaRegistryListSubjects`, **Then** the registry's subjects are listed with version ranges and compatibility, identical in behavior to the sbt 1.x output.
+
+---
+
+### User Story 2 - Existing sbt 1.x users are completely unaffected (Priority: P1)
+
+A developer already using the plugin on sbt 1.x upgrades to the new cross-built release. Their build continues to resolve the same Scala 2.12 artifact, every public setting/task key keeps its name, type, and semantics, and nothing in their build needs to change.
+
+**Why this priority**: Backward compatibility is a hard constraint for a published plugin (per the project's compatibility rules). Adding the Scala 3 axis must not regress or relocate the existing 2.12 / sbt 1.x artifact.
+
+**Independent Test**: Take an existing sbt 1.x consumer build, bump only the plugin version to the cross-built release, and verify it resolves the `_2.12_1.0` artifact and runs all tasks unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** an sbt 1.x build pinned to the previous plugin version, **When** the user bumps to the cross-built version, **Then** the build resolves the Scala 2.12 / sbt 1.x artifact at the expected coordinates and loads without changes.
+2. **Given** the cross-built release, **When** the published artifact list is inspected, **Then** both the sbt 1.x (`_2.12_1.0`) and sbt 2.x (`_sbt2_3`) coordinates are present on the release repository.
+3. **Given** the public key surface, **When** comparing before and after, **Then** no public setting or task key was renamed, retyped, or removed.
+
+---
+
+### User Story 3 - Maintainer builds, tests, and publishes both axes from one source tree (Priority: P2)
+
+A maintainer can compile, run the unit, integration, and scripted test suites, and publish for **both** sbt axes using a single command flow, without forking the source. CI verifies both axes so a regression on either is caught before release.
+
+**Why this priority**: Sustains the feature over time. A cross-build that only one person can reproduce locally, or that CI does not guard, will silently rot back to single-axis.
+
+**Independent Test**: Run the cross aware build/test commands locally and confirm both the 2.12/sbt-1.x and 3.x/sbt-2.x variants compile and pass their suites from the same checkout.
+
+**Acceptance Scenarios**:
+
+1. **Given** the cross-build configuration, **When** the maintainer runs the cross-aware compile, **Then** the plugin compiles for both Scala 2.12 (sbt 1.x) and Scala 3 (sbt 2.x) from the same sources.
+2. **Given** the cross-build configuration, **When** the maintainer runs the test suites, **Then** unit and integration tests pass on both axes and scripted tests run under both sbt versions (fixtures that pull external sbt-1-only plugins are gated to the axis where those plugins exist).
+3. **Given** CI, **When** a change is pushed, **Then** CI compiles and tests both axes and fails the build if either axis breaks.
+
+---
+
+### Edge Cases
+
+- **Task caching silently skipping side effects (sbt 2.x):** sbt 2.x caches all tasks by default. The plugin's tasks are side-effecting and return `Unit`, the exact case the docs warn about — a cached run must not skip the real download/register/list work.
+- **The `it` integration module is sbt-version-coupled:** it depends on an sbt-internal Scala library (`util-logging`) pinned to the current sbt version literal; that exact version has no Scala 3 artifact, so it must track the sbt-2.x version on the Scala 3 axis. It cannot pin an axis independently of the plugin.
+- **`-Xfatal-warnings` promotes Scala-3 warnings to hard errors:** the existing strict-warnings flag turns Scala-3-only deprecations (e.g. legacy Java-collection converters, `Either` projections) into compile failures.
+- **External scripted-fixture plugins may lack an sbt 2.x build:** some scripted fixtures pull external sbt plugins (e.g. sbt-avrohugger) that may not yet publish for sbt 2.x; the scripted suite — not the plugin itself — becomes the scheduling constraint for those fixtures.
+- **Test mocking on Scala 3:** the mock library resolves for Scala 3, but its Scala 3 `mock[T]` macro has stricter (inline) requirements; some specs may need to be reshaped or fall back to a different mocking approach.
+- **Snapshot `<latest>` tags:** several upstream artifacts expose a snapshot as `<latest>`; the build must pin exact stable/GA versions, never resolve `<latest>`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The plugin MUST publish an artifact usable by sbt 2.x builds (a Scala 3 artifact) in addition to the existing sbt 1.x (Scala 2.12) artifact.
+- **FR-002**: The plugin MUST continue to publish the existing sbt 1.x / Scala 2.12 artifact at its current coordinates, with no change to its consumption.
+- **FR-003**: All public setting and task keys MUST keep their names, types, and observable semantics on both axes (no renames, retypes, or removals).
+- **FR-004**: On sbt 2.x, every task (`schemaRegistryDownload`, `schemaRegistryRegister`, `schemaRegistryTestCompatibility`, `schemaRegistryListSubjects`) MUST perform its real side effects on every invocation and MUST NOT be silently skipped by sbt 2.x's default task-result caching.
+- **FR-005**: Both axes MUST be buildable, testable, and publishable from a single shared source tree (no source fork).
+- **FR-006**: The integration (`it`) module MUST build and run its tests on whichever axis is exercised, with its sbt-internal dependency versions decoupled from the plugin's cross-build target so a version bump on one does not unintentionally move the other.
+- **FR-007**: The unit and integration test suites MUST pass on both the Scala 2.12 and Scala 3 axes. The scripted (sbt-plugin e2e) suite MUST run on the sbt-2 axis for every fixture that has no sbt-1-only external-plugin dependency; fixtures that depend on sbt-1-only external plugins (e.g. sbt-avrohugger) MUST stay gated to the sbt-1 axis until those plugins publish sbt-2 builds. The sbt-2 release MUST NOT be blocked by an external plugin's lack of an sbt-2 build.
+- **FR-008**: CI MUST compile and test both axes and fail if either axis regresses.
+- **FR-009**: Strict-warning enforcement (`-Xfatal-warnings`) MUST be in effect on both axes for released builds; it MAY be temporarily relaxed or warning-scoped during migration, then re-enabled once each axis is warning-clean.
+- **FR-010**: The Scala 3 axis MUST pin exact released versions of Scala, sbt 2.x, and all cross-published dependencies (target the latest sbt 2.x GA — currently sbt 2.0.0; never resolve a `<latest>`/snapshot tag).
+- **FR-011**: A single `v*` version tag MUST cross-publish both artifacts (`_2.12_1.0` and `_sbt2_3`) under one version number via the existing tag-triggered release flow — no separate sbt-2 publish step and no per-axis version divergence. The release process and documentation (AGENTS.md stack/commands/release) MUST be updated to describe the dual-axis build, test, and single-tag cross-publish flow.
+
+### Key Entities *(build/release artifacts — no application data)*
+
+- **sbt 1.x artifact**: the existing plugin build, Scala 2.12, sbt-binary 1.0; the artifact today's users consume. Must remain unchanged.
+- **sbt 2.x artifact**: the new plugin build, Scala 3, sbt-binary 2; the artifact sbt-2.x users consume. Published alongside the sbt 1.x artifact.
+- **Cross axis**: the (Scala version → sbt version) mapping that selects which artifact a build resolves (2.12 → sbt 1.x, Scala 3 → sbt 2.x).
+- **`it` module**: integration-test project coupled to the plugin and to an sbt-internal library whose version must track the active sbt axis.
+- **Scripted fixtures**: the sbt-plugin e2e test projects; some pull external sbt plugins whose availability differs per sbt axis.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A from-scratch sbt 2.x project can add the plugin and successfully run all four tasks, producing the same observable results (files written, schemas registered, subjects listed) as the same project on sbt 1.x.
+- **SC-002**: An existing sbt 1.x consumer build upgrades to the cross-built release by changing only the plugin version, with zero other build changes required, and all tasks behave identically.
+- **SC-003**: A single version tag produces both the sbt 1.x and sbt 2.x artifacts under one version number, both resolvable from the release repository.
+- **SC-004**: 100% of the existing public setting/task keys are unchanged in name, type, and semantics after the change.
+- **SC-005**: The test matrix passes and CI enforces it on every change: unit + integration green on both axes; scripted green on sbt-1 for all fixtures and on sbt-2 for every fixture without an sbt-1-only external-plugin dependency (external-plugin fixtures explicitly axis-gated, not silently skipped).
+- **SC-006**: On sbt 2.x, running a side-effecting task twice performs the work both times (no silent cache skip), verified by a scripted or integration check.
+
+## Assumptions
+
+- **Dual cross-build, not sbt-2-only.** Scope keeps the sbt 1.x / Scala 2.12 axis and adds the sbt 2.x / Scala 3 axis. Dropping 2.12 is explicitly out of scope; it would strand current users while sbt 2.x is still stabilizing.
+- **Mechanism (implementation detail, recorded for planning):** sbt 1.x-side `crossScalaVersions` + a `pluginCrossBuild / sbtVersion` mapping keyed on the Scala binary version (sbt ≥ 1.10.2 required; the project is on 1.12.12). `projectMatrix` is an alternative if a shared-source API shim is needed. Source stays shared; version-specific source dirs (`scala-2.12` / `scala-3`) are added only if an API difference forces it.
+- **Dependency availability is confirmed for the Scala 3 axis:** scalatest (3.2.20), mockito-scala-scalatest (2.2.1, the sole `_3` release), and sbt's `util-logging` (sbt-2.x line) all have Scala 3 artifacts. Confluent and Testcontainers deps are plain Java and unaffected.
+- **Source-level fixes required by the Scala 3 axis (mechanical):** replace legacy `scala.collection.JavaConverters` with `scala.jdk.CollectionConverters`; replace `Either` `.right.get`/`.left.get` projections in tests with `EitherValues`; wrap side-effecting task bodies so sbt 2.x caching cannot skip them; possibly reshape mock-based specs for the Scala 3 macro.
+- **sbt 2.x target version:** sbt 2.0.0 GA (the latest sbt 2.x release) and the Scala 3.8.x it ships (3.8.4), both pinned exactly.
+- **Staged rollout is acceptable:** forward-compatible source fixes can land first on the current 2.12 build before the sbt-2 axis is switched on; external scripted-fixture plugin availability (e.g. sbt-avrohugger for sbt 2.x) is verified before that axis is required to be green.
+
+## Out of Scope
+
+- Dropping or deprecating the sbt 1.x / Scala 2.12 axis.
+- Migrating consumer projects to sbt 2.x (this is about the plugin's publishable artifacts, not users' builds).
+- Adding new plugin features or changing task behavior beyond what cross-build correctness requires.
+- Upgrading unrelated dependencies except where a Scala 3 artifact requires a version change.
+
+## Dependencies
+
+- sbt ≥ 1.10.2 on the build side for the `pluginCrossBuild` cross mapping (satisfied: 1.12.12).
+- Availability of Scala 3 artifacts for every `%%` dependency (confirmed) and of sbt-2.x builds for external scripted-fixture plugins (must be verified before requiring the sbt-2 scripted axis to be green).
+- sbt 2.0.0 GA to target and a pinned Scala 3.8.4 release.

--- a/specs/009-sbt2-cross-build/tasks.md
+++ b/specs/009-sbt2-cross-build/tasks.md
@@ -1,0 +1,143 @@
+---
+description: "Task list for Cross-build for sbt 2.x"
+---
+
+# Tasks: Cross-build for sbt 2.x (add a Scala 3 axis)
+
+**Input**: Design documents from `specs/009-sbt2-cross-build/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: This is a build/release feature. "Tests" are the existing three-tier suites re-run on the new axis plus one new scripted fixture for the sbt-2 cache guard (Constitution III). Validation maps to quickstart V1–V6.
+
+**Organization**: Grouped by user story. US1 = sbt 2.x works (P1, the new capability). US2 = sbt 1.x unaffected (P1, the regression guard). US3 = dual build/test/publish from one tree (P2).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, Polish carry no story label)
+
+## Path Conventions
+
+Single cross-built sbt plugin at repo root: `build.sbt`, `project/`, `src/main/scala/`, `src/main/scala-2.12/`, `src/main/scala-3/`, `src/test/scala/`, `src/sbt-test/`, `it/src/test/scala/`, `.github/workflows/`.
+
+---
+
+## Phase 1: Setup (prerequisites & boundary sign-off)
+
+**Purpose**: Lock decisions and clear the two owner-approval boundary items before touching the build.
+
+- [X] T001 Confirm build-side sbt ≥ 1.10.2 (currently 1.12.12 in `project/build.properties`) and fix the exact Scala 3 pin (3.8.x, e.g. `3.8.4`) per research [D1, D2]; record the chosen version as the source of truth for `build.sbt`.
+- [X] T002 [P] Obtain owner approval for the two "ask first" boundary items: adding `scala-collection-compat` (research D5) and editing `.github/workflows/release.yml` to cross-publish (research D12). Block T005/T024 until approved.
+
+**Checkpoint**: target versions fixed; boundary items approved.
+
+---
+
+## Phase 2: Foundational (blocking prerequisites for ALL stories)
+
+**Purpose**: Make one shared source tree cross-compile on Scala 2.12 (sbt 1.x) and Scala 3.8.x (sbt 2.x). Blocks US1, US2, and US3. These are the cross-compatible source rewrites + the `PluginCompat` seam + the cross config.
+
+- [X] T003 [P] Replace `import scala.collection.JavaConverters._` → `import scala.jdk.CollectionConverters._` in the 5 main files: `src/main/scala/org/galaxio/avro/Downloader.scala`, `SubjectExplorer.scala`, `SubjectResolver.scala`, `CompatibilityChecker.scala`, `VersionManifest.scala` [D5].
+- [X] T004 [P] Replace `import scala.collection.JavaConverters._` → `import scala.jdk.CollectionConverters._` in `it/src/test/scala/org/galaxio/avro/ReferenceResolutionIntegrationSpec.scala` [D5].
+- [X] T005 Add `org.scala-lang.modules %% scala-collection-compat` (backports `scala.jdk` to 2.12) in `project/Dependencies.scala` and wire it into `commonSettings` `libraryDependencies` in `build.sbt` [D5]. (depends on T002, T001; makes T003/T004 compile on the 2.12 axis)
+- [X] T006 [P] Replace all 56 `Either` `.right.get`/`.left.get` projection sites with scalatest `EitherValues` (`.value`/`.left.value`) and mix in `EitherValues` across the affected specs under `src/test/scala/org/galaxio/avro/` and `it/src/test/scala/org/galaxio/avro/` [D6].
+- [X] T007 [P] Create `src/main/scala-2.12/org/galaxio/avro/PluginCompat.scala` exposing `private[avro] def uncached[A](a: => A): A = a` (identity, sbt-1 seam) [D4, D7].
+- [X] T008 [P] Create `src/main/scala-3/org/galaxio/avro/PluginCompat.scala` exposing `private[avro] def uncached[A](a: => A): A = Def.uncached(a)` (sbt-2 seam) [D4, D7].
+- [X] T009 Wrap each of the 4 task bodies (`schemaRegistryDownload`, `schemaRegistryRegister`, `schemaRegistryTestCompatibility`, `schemaRegistryListSubjects`) in `PluginCompat.uncached { … }` in `src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala` [D7]. (depends on T007, T008)
+- [X] T010 Decouple and repin `org.scala-sbt %% util-logging` per axis in `build.sbt`/`project/Dependencies.scala` — sbt-1 axis → 1.12.x line, sbt-2 axis → `2.0.0` — selected by `scalaBinaryVersion`, separate from the plugin's `pluginCrossBuild / sbtVersion` literal [D8].
+- [X] T011 Add `crossScalaVersions := Seq("2.12.21","3.8.x")` and the `pluginCrossBuild / sbtVersion` mapping keyed on `scalaBinaryVersion` (2.12 → 1.12.12, else → current sbt 2.x release) in `build.sbt`; add transient `-Wconf` source-version scoping to relax `-Xfatal-warnings` during migration [D1, D13]. (depends on T005, T010)
+
+**Checkpoint**: `sbt +compile` builds both axes from one tree (warnings scoped, not yet strict). US1/US2/US3 can now proceed.
+
+---
+
+## Phase 3: User Story 1 — sbt 2.x project can apply the plugin and run every task (P1)
+
+**Goal**: A fresh sbt 2.x build resolves `_sbt2_3`, applies the plugin, and every task runs with identical observable results — including real side effects on every run (no cache skip).
+
+**Independent test**: From a scratch sbt-2 project, add the plugin, run `schemaRegistryDownload` twice → file written both times; run all four tasks → results match sbt-1.
+
+- [X] T012 [US1] Add a scripted fixture under `src/sbt-test/schema-registry/sbt2-uncached-download/` that runs `schemaRegistryDownload` twice and asserts the schema file is (re)written on the **second** run — proves sbt-2 caching does not skip the side effect [SC-006, V3, D7].
+- [X] T013 [P] [US1] Verify `sbt ++3.8.x compile` is clean on the Scala 3 axis [V4].
+- [X] T014 [P] [US1] Run `sbt ++3.8.x test`; if the `mock[T]` macro fails (Scala 3 inline requirement), refactor the 8 mock specs (`RegistrarSpec`, `SubjectExplorerSpec`, `RetryPolicySpec`, `DownloadOrchestratorSpec`, `DownloaderSpec`, `CompatibilityCheckerSpec`, `SubjectResolverSpec`, `ParallelDownloaderSpec`) to inline call sites or mockito-core [D9].
+- [X] T015 [P] [US1] Run `sbt ++3.8.x it/test` (Docker) green on the Scala 3 axis [SC-005].
+- [X] T016 [US1] Run `sbt ++3.8.x scripted` over the sbt-2-eligible fixtures (incl. T012); external-plugin fixtures stay gated to sbt-1 [D10]. (depends on T012)
+- [X] T017 [US1] Manual V2: in a scratch sbt-2 project, add the plugin, configure URL + one subject, run all four tasks; confirm `_sbt2_3` resolves and files/registry/listing match the sbt-1 result [SC-001].
+
+**Checkpoint**: sbt 2.x consumers fully functional; cache-skip guard proven.
+
+---
+
+## Phase 4: User Story 2 — existing sbt 1.x users completely unaffected (P1)
+
+**Goal**: The `_2.12_1.0` artifact, all public keys, and every behavior are unchanged by the cross-build.
+
+**Independent test**: Bump only the plugin version in an sbt-1 consumer build → resolves `_2.12_1.0`, all tasks behave as before, zero other changes.
+
+- [X] T018 [P] [US2] Verify `sbt ++2.12.21 compile test` green (regression on the sbt-1 axis) [US2].
+- [X] T019 [P] [US2] Verify `sbt ++2.12.21 it/test` green (Docker) [US2].
+- [X] T020 [P] [US2] Verify the **full** scripted suite green on sbt-1 (`sbt ++2.12.21 scripted`), all fixtures, unchanged [D14, US2].
+- [X] T021 [US2] Public-key-surface review against `contracts/plugin-api.md` — confirm no key renamed/retyped/removed and all defaults unchanged [SC-004, D14].
+- [X] T022 [US2] Confirm the `_2.12_1.0` coordinate and version scheme are unchanged (V1, FR-002).
+
+**Checkpoint**: backward compatibility proven; sbt-1 users see no change.
+
+---
+
+## Phase 5: User Story 3 — build, test, publish both axes from one tree (P2)
+
+**Goal**: CI guards both axes; a single `v*` tag cross-publishes both coordinates; docs describe the dual-axis flow.
+
+**Independent test**: Push a change → CI compiles+tests both axes and fails if either breaks; a tag dry-run emits both `_2.12_1.0` and `_sbt2_3`.
+
+- [X] T023 [US3] Add a Scala-axis matrix (`2.12.21`, `3.8.x`) to `.github/workflows/ci.yml`: each leg runs compile + test + it/test; scripted runs per-fixture axis-gated; keep the `scalafmtCheckAll scalafmtSbtCheck` gate [D11, FR-008].
+- [X] T024 [US3] Update `.github/workflows/release.yml` so a single `v*` tag runs `sbt-ci-release` in cross form (`+publishSigned` aggregate) emitting both coordinates under one version [D12, FR-011]. (requires T002 approval)
+- [X] T025 [P] [US3] Update `AGENTS.md` (Stack, Commands, Release Process) to describe the dual-axis build/test/single-tag cross-publish flow [FR-011].
+- [X] T026 [US3] Validate V5 (full matrix green in CI) and V6 (tag dry-run / inspection emits both `_2.12_1.0` and `_sbt2_3` under one version) [SC-003, SC-005].
+
+**Checkpoint**: dual-axis CI + release operational and documented.
+
+---
+
+## Phase 6: Polish & cross-cutting
+
+**Purpose**: Restore the strict gate and final formatting.
+
+- [X] T027 Remove the transient `-Wconf` migration scoping and re-enable `-Xfatal-warnings` on **both** axes; confirm `sbt +compile` is warning-clean (Constitution V, D13).
+- [X] T028 [P] Run `sbt scalafmtAll scalafmtSbt`, then the full gate `sbt scalafmtCheckAll scalafmtSbtCheck +compile +test` green.
+- [X] T029 [P] If T014 refactored mock specs, confirm their assertions produce identical results on both axes (no behavior drift) [D9].
+
+---
+
+## Dependencies
+
+```text
+Setup (T001, T002)
+   └─> Foundational (T003–T011)            # T005 needs T002+T001; T009 needs T007+T008; T011 needs T005+T010
+          ├─> US1 (T012–T017)              # P1 — new capability
+          ├─> US2 (T018–T022)              # P1 — regression guard
+          └─> US3 (T023–T026)              # P2 — needs US1+US2 green; T024 needs T002
+                 └─> Polish (T027–T029)
+```
+
+- **Foundational blocks everything** — nothing cross-compiles until T003–T011 land.
+- **US1 and US2 are independent** of each other (different axes, different validation) and can run in parallel once Foundational is done.
+- **US3** should follow US1+US2 being green (CI/release codify what those prove). **T024** also gated on T002 approval.
+- **Polish** last: re-enabling `-Xfatal-warnings` (T027) must come after both axes compile clean.
+
+## Parallel execution examples
+
+- **Foundational**: T003, T004, T006, T007, T008 are all `[P]` (distinct files) — run together; then T005 → T009 → T010 → T011 in order.
+- **After Foundational**: launch US1 (T013, T014, T015 in parallel) and US2 (T018, T019, T020 in parallel) concurrently — two axes, no shared files.
+- **US3 docs**: T025 `[P]` can be written while T023/T024 workflows are wired.
+
+## Implementation strategy
+
+1. **Land the forward-compatible fixes first (T003, T004, T006 + T005).** These improve the *current* sbt-1 build with zero downside and de-risk everything later — can merge before the axis is switched on.
+2. **Add the seam + cross config (T007–T011).** Build now cross-compiles.
+3. **MVP = US1 (T012–T017):** sbt 2.x consumers can use the plugin — the actual value of this feature.
+4. **Guard with US2 (T018–T022)** in parallel — proves no sbt-1 regression.
+5. **Codify in US3 (T023–T026)** so CI/release sustain both axes.
+6. **Polish (T027–T029):** restore the strict warning gate, format, verify.
+
+**MVP scope**: Phases 1–2 + Phase 3 (US1), with Phase 4 (US2) run alongside as the safety net — together they deliver "sbt 2.x works, sbt 1.x unbroken." US3 and Polish make it durable and releasable.

--- a/src/main/scala-2.12/org/galaxio/avro/PluginCompat.scala
+++ b/src/main/scala-2.12/org/galaxio/avro/PluginCompat.scala
@@ -1,0 +1,18 @@
+package org.galaxio.avro
+
+import sbt.Def
+
+/** sbt-version compatibility seam — sbt 1.x / Scala 2.12 axis.
+  *
+  * `Def.uncached` is provided here as a no-op enrichment (mirroring the sbt2-compat shim) so the shared task bodies can call
+  * `Def.uncached { ... }` uniformly on both axes; on the sbt 1.x axis it is a fallback — there is no
+  * all-tasks-cached-by-default behaviour to opt out of. On the sbt 2.x axis (`src/main/scala-3`) `Def.uncached` is native and
+  * forces side-effecting tasks to re-run every invocation instead of being served from the task cache.
+  *
+  * Shared sources wildcard-import this object; do not import members by name (the scala-3 variant is intentionally empty).
+  */
+private[avro] object PluginCompat {
+  implicit class DefOps(private val d: Def.type) extends AnyVal {
+    def uncached[A](a: A): A = a
+  }
+}

--- a/src/main/scala-3/org/galaxio/avro/PluginCompat.scala
+++ b/src/main/scala-3/org/galaxio/avro/PluginCompat.scala
@@ -1,0 +1,8 @@
+package org.galaxio.avro
+
+/** sbt-version compatibility seam — sbt 2.x / Scala 3 axis.
+  *
+  * `Def.uncached` is native in sbt 2.x, so no enrichment is defined here. The shared sources wildcard-import this object; on
+  * this axis it intentionally provides nothing.
+  */
+private[avro] object PluginCompat

--- a/src/main/scala/org/galaxio/avro/CompatibilityChecker.scala
+++ b/src/main/scala/org/galaxio/avro/CompatibilityChecker.scala
@@ -2,7 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object CompatibilityChecker {

--- a/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
+++ b/src/main/scala/org/galaxio/avro/DownloadOrchestrator.scala
@@ -66,7 +66,7 @@ object DownloadOrchestrator {
     if (cfg.patterns.isEmpty) Right(cfg.subjects.toList)
     else {
       val specs =
-        cfg.subjects.map(s => SubjectSpec.Exact(s)).toList ++ cfg.patterns.map(SubjectSpec.Pattern).toList
+        cfg.subjects.map(s => SubjectSpec.Exact(s)).toList ++ cfg.patterns.map(p => SubjectSpec.Pattern(p)).toList
       SubjectResolver.resolve(client, specs).map { plan =>
         logger.info(s"Resolved ${plan.subjects.size} subject(s) from patterns")
         plan.subjects.toList

--- a/src/main/scala/org/galaxio/avro/Downloader.scala
+++ b/src/main/scala/org/galaxio/avro/Downloader.scala
@@ -6,7 +6,7 @@ import sbt.util.Logger
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.{Collections, HashMap => JHashMap}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 final class Downloader private[avro] (

--- a/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
+++ b/src/main/scala/org/galaxio/avro/SchemaDownloaderPlugin.scala
@@ -3,6 +3,7 @@ package org.galaxio.avro
 import _root_.io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import sbt.*
 import Keys.*
+import PluginCompat._ // provides Def.uncached (no-op shim on the sbt-1 axis; native on sbt-2)
 
 import scala.util.Using
 
@@ -63,7 +64,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
 
   override lazy val projectSettings: Seq[Setting[?]] = defaultSettings ++ Seq(
     schemaRegistryDownload                    := (Compile / schemaRegistryDownload).value,
-    Compile / schemaRegistryDownload          := {
+    Compile / schemaRegistryDownload          := Def.uncached {
       val logger      = streams.value.log
       val subjects    = schemaRegistrySubjects.value
       val patterns    = schemaRegistrySubjectPatterns.value
@@ -122,7 +123,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       }
     },
     schemaRegistryRegister                    := (Compile / schemaRegistryRegister).value,
-    Compile / schemaRegistryRegister          := {
+    Compile / schemaRegistryRegister          := Def.uncached {
       val logger        = streams.value.log
       val registrations = schemaRegistryRegistrations.value.toList
 
@@ -149,7 +150,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       }
     },
     schemaRegistryTestCompatibility           := (Compile / schemaRegistryTestCompatibility).value,
-    Compile / schemaRegistryTestCompatibility := {
+    Compile / schemaRegistryTestCompatibility := Def.uncached {
       val logger        = streams.value.log
       val registrations = schemaRegistryRegistrations.value.toList
 
@@ -177,7 +178,7 @@ object SchemaDownloaderPlugin extends AutoPlugin {
       }
     },
     schemaRegistryListSubjects                := (Compile / schemaRegistryListSubjects).value,
-    Compile / schemaRegistryListSubjects      := {
+    Compile / schemaRegistryListSubjects      := Def.uncached {
       val logger      = streams.value.log
       val filter      = schemaRegistrySubjectFilter.value
       val parallelism = schemaRegistryParallelism.value

--- a/src/main/scala/org/galaxio/avro/SubjectExplorer.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectExplorer.scala
@@ -2,7 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 /** Pure core for the list-subjects task: fetch + transform, no logging or side effects beyond the injected client. Presentation
@@ -20,7 +20,7 @@ object SubjectExplorer {
   ): Either[DownloadError, SubjectListing] =
     for {
       names <- Try(client.getAllSubjects.asScala.toList.sorted).toEither.left
-                 .map(DownloadError.SubjectListFailed)
+                 .map(e => DownloadError.SubjectListFailed(e))
       // Filter by name BEFORE per-subject fetch: avoids fetching versions/compatibility for subjects
       // the user excluded, and scopes fail-fast to the subjects actually requested.
       infos <- fetchInfos(client, filterNames(names, filter), parallelism)
@@ -38,7 +38,7 @@ object SubjectExplorer {
       parallelism: Int,
   ): Either[DownloadError, List[SubjectInfo]] =
     Try(BoundedParallel.traverse(names, parallelism)(fetchInfo(client, _))).toEither.left
-      .map(DownloadError.SubjectListFailed)
+      .map(e => DownloadError.SubjectListFailed(e))
       .flatMap(EitherOps.sequence)
 
   private def fetchInfo(

--- a/src/main/scala/org/galaxio/avro/SubjectResolver.scala
+++ b/src/main/scala/org/galaxio/avro/SubjectResolver.scala
@@ -2,7 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object SubjectResolver {
@@ -43,7 +43,7 @@ object SubjectResolver {
       compiled: List[scala.util.matching.Regex],
   ): Either[DownloadError, List[RegistrySubject]] =
     Try(client.getAllSubjects.asScala.toList).toEither.left
-      .map(DownloadError.SubjectListFailed)
+      .map(e => DownloadError.SubjectListFailed(e))
       .map { allNames =>
         allNames
           .filter(name => compiled.exists(_.pattern.matcher(name).matches()))

--- a/src/main/scala/org/galaxio/avro/VersionManifest.scala
+++ b/src/main/scala/org/galaxio/avro/VersionManifest.scala
@@ -3,7 +3,7 @@ package org.galaxio.avro
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 final case class VersionManifest(versions: Map[String, Int]) {

--- a/src/sbt-test/schema-registry/hook-compile/sbt2-skip
+++ b/src/sbt-test/schema-registry/hook-compile/sbt2-skip
@@ -1,0 +1,10 @@
+# Gated off the sbt 2.x scripted axis (CI reads this marker; see .github/workflows/ci.yml).
+#
+# This fixture overrides `Compile / compile := (Compile / compile).dependsOn(...).value`.
+# sbt 2.x caches all tasks by default and refuses to redefine `compile` because its
+# CompileAnalysis result has no sjsonnew.JsonFormat ("opt out ... as foo := Def.uncached(...)").
+# The user-side fix is `Def.uncached(...)`, which is sbt-2-only and cannot live in a shared
+# fixture build.sbt that must also evaluate under sbt 1.x.
+#
+# The cross-axis-safe "run download before compile" pattern is covered by the hook-source-generators
+# fixture (`Compile / sourceGenerators`), which runs on both axes. This fixture stays sbt-1-only.

--- a/src/sbt-test/schema-registry/hook-empty-subjects/sbt2-skip
+++ b/src/sbt-test/schema-registry/hook-empty-subjects/sbt2-skip
@@ -1,0 +1,5 @@
+# Gated off the sbt 2.x scripted axis (CI reads this marker; see .github/workflows/ci.yml).
+#
+# Same reason as hook-compile: overrides `Compile / compile := (Compile / compile).dependsOn(...).value`,
+# which sbt 2.x rejects (CompileAnalysis has no JsonFormat; needs Def.uncached, sbt-2-only). The
+# cross-axis-safe hook is covered by hook-source-generators. This fixture stays sbt-1-only.

--- a/src/sbt-test/schema-registry/sbt2-uncached-download/build.sbt
+++ b/src/sbt-test/schema-registry/sbt2-uncached-download/build.sbt
@@ -1,0 +1,19 @@
+import org.galaxio.avro.RegistrySubject
+
+// Guards the sbt 2.x task-caching behaviour: all tasks are cached by default and a cache hit
+// silently skips side effects. The download task is wrapped in `Def.uncached` (no-op on sbt 1.x,
+// native on sbt 2.x) so it re-executes every invocation. The `test` script proves it by deleting
+// the downloaded file between two identical invocations and asserting it reappears.
+//
+// `schemaRegistryIncremental := false` is essential here: with incremental on (the default), the
+// second download would be skipped by the plugin's OWN manifest logic (the deleted file isn't in
+// the manifest as changed), which would mask — not test — sbt 2.x task caching. With incremental
+// off the task always re-writes, so a skipped second run can only mean the sbt 2.x task cache
+// served the result without running the body — exactly what Def.uncached must prevent.
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion            := "2.12.21",
+    schemaRegistryUrl       := RegistryFixture.url,
+    schemaRegistryIncremental := false,
+    schemaRegistrySubjects += RegistrySubject(RegistryFixture.subject, 1),
+  )

--- a/src/sbt-test/schema-registry/sbt2-uncached-download/project/RegistryFixture.scala
+++ b/src/sbt-test/schema-registry/sbt2-uncached-download/project/RegistryFixture.scala
@@ -1,0 +1,44 @@
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import org.apache.avro.Schema
+import org.testcontainers.containers.{GenericContainer => JGenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+object RegistryFixture {
+  val subjectA    = "it.e2e.Order"
+  val subject     = subjectA
+  val schemaJsonA =
+    """{"type":"record","name":"Order","namespace":"it.e2e","fields":[{"name":"id","type":"long"}]}"""
+
+  val subjectB    = "it.e2e.User"
+  val schemaJsonB =
+    """{"type":"record","name":"User","namespace":"it.e2e","fields":[{"name":"name","type":"string"}]}"""
+
+  private val confluentTag = "7.5.0"
+
+  lazy val url: String = {
+    val network = Network.newNetwork()
+
+    val kafka = new ConfluentKafkaContainer(DockerImageName.parse(s"confluentinc/cp-kafka:$confluentTag"))
+    kafka.withListener("kafka:19092")
+    kafka.withNetwork(network)
+    kafka.start()
+
+    val sr = new JGenericContainer(DockerImageName.parse(s"confluentinc/cp-schema-registry:$confluentTag"))
+    sr.withNetwork(network)
+    sr.withExposedPorts(8081)
+    sr.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+    sr.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+    sr.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+    sr.start()
+
+    val u      = s"http://${sr.getHost}:${sr.getMappedPort(8081)}"
+    val client = new CachedSchemaRegistryClient(u, 10)
+    client.register(subjectA, new AvroSchema(new Schema.Parser().parse(schemaJsonA)))
+    client.register(subjectB, new AvroSchema(new Schema.Parser().parse(schemaJsonB)))
+    client.close()
+    u
+  }
+}

--- a/src/sbt-test/schema-registry/sbt2-uncached-download/project/plugins.sbt
+++ b/src/sbt-test/schema-registry/sbt2-uncached-download/project/plugins.sbt
@@ -1,0 +1,8 @@
+resolvers ++= Seq("Confluent" at "https://packages.confluent.io/maven/")
+
+libraryDependencies += "org.testcontainers" % "kafka" % "1.21.3"
+
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("org.galaxio" % "sbt-schema-registry-plugin" % v)
+  case None    => sys.error("plugin.version system property not set (provided by scriptedLaunchOpts)")
+}

--- a/src/sbt-test/schema-registry/sbt2-uncached-download/test
+++ b/src/sbt-test/schema-registry/sbt2-uncached-download/test
@@ -1,0 +1,12 @@
+# sbt 2.x caches all tasks by default; a cache hit returns the prior result and silently skips
+# side effects. schemaRegistryDownload is wrapped in Def.uncached so it must re-run every time.
+# Prove it: download, delete the output, download again with identical inputs — the file must
+# reappear. Were the second invocation served from the task cache, the file would stay deleted
+# and `exists` would fail (this is the regression this fixture guards). No-op-safe on sbt 1.x.
+# Invoke the bare root task (what users run) — it delegates to Compile / schemaRegistryDownload.
+> schemaRegistryDownload
+$ exists src/main/avro/it.e2e.Order-1.avsc
+$ delete src/main/avro/it.e2e.Order-1.avsc
+$ absent src/main/avro/it.e2e.Order-1.avsc
+> schemaRegistryDownload
+$ exists src/main/avro/it.e2e.Order-1.avsc

--- a/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloadOrchestratorSpec.scala
@@ -5,6 +5,7 @@ import io.confluent.kafka.schemaregistry.client.{SchemaMetadata, SchemaRegistryC
 import org.mockito.ArgumentMatchers.{anyBoolean, anyInt, anyString}
 import org.mockito.Mockito.{verify, when}
 import org.mockito.MockitoSugar
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sbt.util.Logger
@@ -108,13 +109,13 @@ class DownloadOrchestratorSpec extends AnyFlatSpec with Matchers with MockitoSug
   it should "return Left for an out-of-range parallelism without touching the registry" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     val cfg    = config(dir, Seq(RegistrySubject("x", 1))).copy(parallelism = 99)
-    DownloadOrchestrator.run(client, cfg, testLogger).left.get shouldBe a[DownloadError.InvalidParallelism]
+    DownloadOrchestrator.run(client, cfg, testLogger).left.value shouldBe a[DownloadError.InvalidParallelism]
   }
 
   it should "return Left for an out-of-range retry count" in withTempDir { dir =>
     val client = mock[SchemaRegistryClient]
     val cfg    = config(dir, Seq(RegistrySubject("x", 1))).copy(retries = -1)
-    DownloadOrchestrator.run(client, cfg, testLogger).left.get shouldBe a[DownloadError.InvalidRetryConfig]
+    DownloadOrchestrator.run(client, cfg, testLogger).left.value shouldBe a[DownloadError.InvalidRetryConfig]
   }
 
   it should "fail fast with Left when a subject pattern is an invalid regex" in withTempDir { dir =>
@@ -124,7 +125,7 @@ class DownloadOrchestratorSpec extends AnyFlatSpec with Matchers with MockitoSug
     val result = DownloadOrchestrator.run(client, cfg, testLogger)
 
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DownloadError.InvalidPattern]
+    result.left.value shouldBe a[DownloadError.InvalidPattern]
   }
 
   it should "download all subjects without touching the manifest when incremental is disabled" in withTempDir { dir =>

--- a/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
+++ b/src/test/scala/org/galaxio/avro/DownloaderSpec.scala
@@ -5,6 +5,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Schema
 import org.mockito.ArgumentMatchers.{anyBoolean, anyInt, anyString}
 import org.mockito.Mockito.when
 import org.mockito.MockitoSugar
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sbt.util.Logger
@@ -80,8 +81,8 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result     = downloader.schemaSubjectToFile(RegistrySubject("fail-subject", 1))
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
-    result.left.get.message should include("Connection refused")
+    result.left.value shouldBe a[DownloadError.SchemaFetchFailed]
+    result.left.value.message should include("Connection refused")
   }
 
   it should "return Left with SchemaFetchFailed when schema not found" in withTempDir { dir =>
@@ -93,7 +94,7 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result     = downloader.schemaSubjectToFile(RegistrySubject("missing", 1))
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.SchemaFetchFailed]
+    result.left.value shouldBe a[DownloadError.SchemaFetchFailed]
   }
 
   it should "use correct file extension" in withTempDir { dir =>
@@ -154,8 +155,8 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result     = downloader.schemaSubjectToFile(RegistrySubject("a/b", 1))
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.InvalidSubjectName]
-    result.left.get.message should include("path separators")
+    result.left.value shouldBe a[DownloadError.InvalidSubjectName]
+    result.left.value.message should include("path separators")
   }
 
   it should "return Left with InvalidSubjectName for backslash" in withTempDir { dir =>
@@ -164,8 +165,8 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result     = downloader.schemaSubjectToFile(RegistrySubject("a\\b", 1))
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.InvalidSubjectName]
-    result.left.get.message should include("path separators")
+    result.left.value shouldBe a[DownloadError.InvalidSubjectName]
+    result.left.value.message should include("path separators")
   }
 
   it should "return Left with WriteError when output path is not writable" in withTempDir { dir =>
@@ -180,7 +181,7 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result     = downloader.schemaSubjectToFile(RegistrySubject("test", 1))
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.WriteError]
+    result.left.value shouldBe a[DownloadError.WriteError]
   }
 
   it should "be safe to call close multiple times" in withTempDir { dir =>
@@ -266,7 +267,7 @@ class DownloaderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result     = downloader.schemaSubjectToFile(RegistrySubject.latest("unknown-type"))
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.UnsupportedSchemaType]
+    result.left.value shouldBe a[DownloadError.UnsupportedSchemaType]
   }
 
   it should "download pinned schema with Protobuf type using .proto extension" in withTempDir { dir =>

--- a/src/test/scala/org/galaxio/avro/RegistrarSpec.scala
+++ b/src/test/scala/org/galaxio/avro/RegistrarSpec.scala
@@ -5,6 +5,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.mockito.MockitoSugar
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -67,7 +68,7 @@ class RegistrarSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     results should have size 2
     results(0) shouldBe Right(RegisteredSchema("sub1", 1))
     results(1) shouldBe a[Left[_, _]]
-    results(1).left.get shouldBe RegistryError.FileNotFound(f2)
+    results(1).left.value shouldBe RegistryError.FileNotFound(f2)
   }
 
   it should "handle empty registration list" in {
@@ -86,9 +87,9 @@ class RegistrarSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val results = Registrar.registerAll(client, List(RegistryRegistration("fail-sub", f)))
     results should have size 1
     results.head shouldBe a[Left[_, _]]
-    results.head.left.get shouldBe a[RegistryError.RegistrationFailed]
-    results.head.left.get.message should include("fail-sub")
-    results.head.left.get.message should include("Connection refused")
+    results.head.left.value shouldBe a[RegistryError.RegistrationFailed]
+    results.head.left.value.message should include("fail-sub")
+    results.head.left.value.message should include("Connection refused")
   }
 
   "Registrar.partitionResults" should "separate errors and successes" in {
@@ -115,52 +116,52 @@ class RegistrarSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   "Registrar.buildParsedSchema" should "build Avro schema from valid content" in {
     val result = Registrar.buildParsedSchema("test", """{"type":"string"}""", SchemaType.Avro)
     result shouldBe a[Right[_, _]]
-    result.right.get.schemaType() shouldBe "AVRO"
+    result.value.schemaType() shouldBe "AVRO"
   }
 
   it should "return RegistrationFailed for invalid Avro content" in {
     val result = Registrar.buildParsedSchema("test", "not valid avro", SchemaType.Avro)
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[RegistryError.RegistrationFailed]
+    result.left.value shouldBe a[RegistryError.RegistrationFailed]
   }
 
   it should "return RegistrationFailed for Protobuf when provider not on classpath" in {
     val result = Registrar.buildParsedSchema("test", "syntax = \"proto3\";", SchemaType.Protobuf)
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[RegistryError.RegistrationFailed]
-    result.left.get.message should include("Schema provider not on classpath")
+    result.left.value shouldBe a[RegistryError.RegistrationFailed]
+    result.left.value.message should include("Schema provider not on classpath")
   }
 
   it should "return RegistrationFailed for Json when provider not on classpath" in {
     val result = Registrar.buildParsedSchema("test", """{"type":"object"}""", SchemaType.Json)
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[RegistryError.RegistrationFailed]
-    result.left.get.message should include("Schema provider not on classpath")
+    result.left.value shouldBe a[RegistryError.RegistrationFailed]
+    result.left.value.message should include("Schema provider not on classpath")
   }
 
   it should "build Avro schema with references" in {
     val refs   = List(SchemaReference("Base", "base-subject", 1))
     val result = Registrar.buildParsedSchema("test", """{"type":"string"}""", SchemaType.Avro, refs)
     result shouldBe a[Right[_, _]]
-    result.right.get.references() should have size 1
+    result.value.references() should have size 1
   }
 
   it should "be extension-agnostic — schema type is determined by the SchemaType parameter, not the file" in {
     val result = Registrar.buildParsedSchema("test", """{"type":"string"}""", SchemaType.Avro)
     result shouldBe a[Right[_, _]]
-    result.right.get.schemaType() shouldBe "AVRO"
+    result.value.schemaType() shouldBe "AVRO"
   }
 
   it should "include dependency name in error for missing Protobuf provider" in {
     val result = Registrar.buildParsedSchema("test", "syntax = \"proto3\";", SchemaType.Protobuf)
     result shouldBe a[Left[_, _]]
-    result.left.get.message should include("kafka-protobuf-provider")
+    result.left.value.message should include("kafka-protobuf-provider")
   }
 
   it should "include dependency name in error for missing JSON provider" in {
     val result = Registrar.buildParsedSchema("test", """{"type":"object"}""", SchemaType.Json)
     result shouldBe a[Left[_, _]]
-    result.left.get.message should include("kafka-json-schema-provider")
+    result.left.value.message should include("kafka-json-schema-provider")
   }
 
   "Registrar.registerAll" should "pass references from RegistryRegistration to client" in {

--- a/src/test/scala/org/galaxio/avro/SubjectExplorerSpec.scala
+++ b/src/test/scala/org/galaxio/avro/SubjectExplorerSpec.scala
@@ -2,6 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.mockito.MockitoSugar
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -30,7 +31,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectExplorer.listAll(client, None)
 
     result shouldBe a[Right[_, _]]
-    result.right.get.subjects.map(_.name) shouldBe List("order-value", "payment-value", "user-value")
+    result.value.subjects.map(_.name) shouldBe List("order-value", "payment-value", "user-value")
   }
 
   it should "extract the version list for each subject" in {
@@ -39,7 +40,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     when(client.getAllVersions("a-value")).thenReturn(jints(1, 2, 3))
     when(client.getCompatibility("a-value")).thenThrow(new RuntimeException("40401"))
 
-    val info = SubjectExplorer.listAll(client, None).right.get.subjects.head
+    val info = SubjectExplorer.listAll(client, None).value.subjects.head
     info.versions shouldBe List(1, 2, 3)
     info.versionRange shouldBe "1..3"
   }
@@ -50,7 +51,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val result = SubjectExplorer.listAll(client, None)
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.SubjectListFailed]
+    result.left.value shouldBe a[DownloadError.SubjectListFailed]
   }
 
   it should "fail-fast with SubjectVersionsFetchFailed naming the subject whose versions cannot be fetched" in {
@@ -62,7 +63,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val result = SubjectExplorer.listAll(client, None)
     result shouldBe a[Left[_, _]]
-    val err    = result.left.get
+    val err    = result.left.value
     err shouldBe a[DownloadError.SubjectVersionsFetchFailed]
     err.asInstanceOf[DownloadError.SubjectVersionsFetchFailed].subject shouldBe "bad-value"
   }
@@ -71,12 +72,12 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   it should "filter case-insensitively by substring" in {
     val client = clientWith("user-value", "order-value", "payment-value")
-    SubjectExplorer.listAll(client, Some("ORDER")).right.get.subjects.map(_.name) shouldBe List("order-value")
+    SubjectExplorer.listAll(client, Some("ORDER")).value.subjects.map(_.name) shouldBe List("order-value")
   }
 
   it should "treat an empty filter as 'list all'" in {
     val client = clientWith("user-value", "order-value")
-    SubjectExplorer.listAll(client, Some("")).right.get.size shouldBe 2
+    SubjectExplorer.listAll(client, Some("")).value.size shouldBe 2
   }
 
   it should "not fetch or fail on subjects excluded by the filter" in {
@@ -89,7 +90,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val result = SubjectExplorer.listAll(client, Some("order"))
     result shouldBe a[Right[_, _]]
-    result.right.get.subjects.map(_.name) shouldBe List("order-value")
+    result.value.subjects.map(_.name) shouldBe List("order-value")
     verify(client, org.mockito.Mockito.never()).getAllVersions("broken-value")
   }
 
@@ -97,7 +98,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   it should "produce the same sorted result with parallelism > 1" in {
     val client = clientWith("user-value", "order-value", "payment-value")
-    SubjectExplorer.listAll(client, None, parallelism = 4).right.get.subjects.map(_.name) shouldBe
+    SubjectExplorer.listAll(client, None, parallelism = 4).value.subjects.map(_.name) shouldBe
       List("order-value", "payment-value", "user-value")
   }
 
@@ -110,7 +111,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val result = SubjectExplorer.listAll(client, None, parallelism = 4)
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.SubjectVersionsFetchFailed]
+    result.left.value shouldBe a[DownloadError.SubjectVersionsFetchFailed]
   }
 
   it should "report the first failing subject in sorted order when several fail (parallel)" in {
@@ -121,7 +122,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val result = SubjectExplorer.listAll(client, None, parallelism = 4)
     result shouldBe a[Left[_, _]]
-    result.left.get.asInstanceOf[DownloadError.SubjectVersionsFetchFailed].subject shouldBe "a-bad"
+    result.left.value.asInstanceOf[DownloadError.SubjectVersionsFetchFailed].subject shouldBe "a-bad"
   }
 
   // --- US3: versions + compatibility (debugging) ---
@@ -132,7 +133,7 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     when(client.getAllVersions("c-value")).thenReturn(jints(1))
     when(client.getCompatibility("c-value")).thenReturn("BACKWARD")
 
-    SubjectExplorer.listAll(client, None).right.get.subjects.head.compatibility shouldBe Some("BACKWARD")
+    SubjectExplorer.listAll(client, None).value.subjects.head.compatibility shouldBe Some("BACKWARD")
   }
 
   it should "report None compatibility (best-effort) when getCompatibility throws, without failing the task" in {
@@ -143,6 +144,6 @@ class SubjectExplorerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val result = SubjectExplorer.listAll(client, None)
     result shouldBe a[Right[_, _]]
-    result.right.get.subjects.head.compatibility shouldBe None
+    result.value.subjects.head.compatibility shouldBe None
   }
 }

--- a/src/test/scala/org/galaxio/avro/SubjectResolverSpec.scala
+++ b/src/test/scala/org/galaxio/avro/SubjectResolverSpec.scala
@@ -2,6 +2,7 @@ package org.galaxio.avro
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.mockito.MockitoSugar
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -26,7 +27,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Right[_, _]]
-    val plan = result.right.get
+    val plan = result.value
     plan.subjects.map(_.name) should contain theSameElementsAs List(
       "com.myorg.User-value",
       "com.myorg.Order-value",
@@ -39,7 +40,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Right[_, _]]
-    result.right.get.subjects shouldBe empty
+    result.value.subjects shouldBe empty
   }
 
   it should "return Left(InvalidPattern) for invalid regex" in {
@@ -48,7 +49,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.InvalidPattern]
+    result.left.value shouldBe a[DownloadError.InvalidPattern]
   }
 
   it should "fail-fast on invalid regex without calling getAllSubjects" in {
@@ -73,7 +74,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Right[_, _]]
-    result.right.get.subjects shouldBe List(RegistrySubject.Latest("com.myorg.User-value"))
+    result.value.subjects shouldBe List(RegistrySubject.Latest("com.myorg.User-value"))
   }
 
   // --- Deduplication ---
@@ -86,7 +87,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Right[_, _]]
-    val plan = result.right.get
+    val plan = result.value
     plan.subjects should contain(RegistrySubject.Pinned("com.myorg.User-value", 3))
     plan.subjects.count(_.name == "com.myorg.User-value") shouldBe 1
   }
@@ -99,7 +100,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Right[_, _]]
-    val names = result.right.get.subjects.map(_.name)
+    val names = result.value.subjects.map(_.name)
     names should contain("com.myorg.Order-value")
   }
 
@@ -114,7 +115,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Right[_, _]]
-    result.right.get.subjects.map(_.name) should contain theSameElementsAs List(
+    result.value.subjects.map(_.name) should contain theSameElementsAs List(
       "com.myorg.User-value",
       "internal.Audit-value",
     )
@@ -129,7 +130,7 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Right[_, _]]
-    val names = result.right.get.subjects.map(_.name)
+    val names = result.value.subjects.map(_.name)
     names.count(_ == "com.myorg.User-value") shouldBe 1
   }
 
@@ -161,6 +162,6 @@ class SubjectResolverSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val result = SubjectResolver.resolve(client, specs)
 
     result shouldBe a[Left[_, _]]
-    result.left.get shouldBe a[DownloadError.SubjectListFailed]
+    result.left.value shouldBe a[DownloadError.SubjectListFailed]
   }
 }

--- a/src/test/scala/org/galaxio/avro/VersionManifestSpec.scala
+++ b/src/test/scala/org/galaxio/avro/VersionManifestSpec.scala
@@ -1,5 +1,6 @@
 package org.galaxio.avro
 
+import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -64,7 +65,7 @@ class VersionManifestSpec extends AnyFlatSpec with Matchers {
   "fromJson" should "return Left for invalid JSON" in {
     val result = VersionManifest.fromJson("not json")
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DownloadError.ManifestParseError]
+    result.left.value shouldBe a[DownloadError.ManifestParseError]
   }
 
   it should "return Left for empty string" in {


### PR DESCRIPTION
Replaces the soft `"Use AGENTS.md"` instruction with `@AGENTS.md` so Claude Code loads project instructions automatically on every session, rather than relying on the agent to follow a text directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)